### PR TITLE
Add mojo for generating aggregate bom for multi module projects

### DIFF
--- a/src/main/java/org/cyclonedx/maven/CycloneDxAggregateMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxAggregateMojo.java
@@ -1,0 +1,32 @@
+package org.cyclonedx.maven;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.cyclonedx.maven.model.Component;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Mojo(
+        name = "makeAggregateBom",
+        defaultPhase = LifecyclePhase.VERIFY,
+        aggregator = true,
+        requiresOnline = true,
+        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME
+)
+public class CycloneDxAggregateMojo extends BaseCycloneDxMojo {
+
+    public void execute() throws MojoExecutionException{
+
+        final Set<Component> components = getReactorProjects().stream()
+                .flatMap(mavenProject -> mavenProject.getArtifacts().stream())
+                .filter(this::shouldInclude)
+                .map(this::convert)
+                .collect(Collectors.toSet());
+
+        super.execute(components);
+    }
+}
+


### PR DESCRIPTION
This adds the goal `makeAggregateBom` which allows users to generate a aggregated bom at the top level, containing all the artifacts in the submodules.