### PR TITLE
Add optional configuration parameter "includeLicenses".

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Default Values
             <includeSystemScope>true</includeSystemScope>
             <includeTestScope>false</includeTestScope>
             <includeDependencyGraph>true</includeDependencyGraph>
+            <includeLicenses>true</includeLicenses>
         </configuration>
     </plugin>
 </plugins>

--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -104,6 +104,9 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
     @Parameter(property = "includeDependencyGraph", defaultValue = "true", required = false)
     private Boolean includeDependencyGraph;
 
+    @Parameter(property = "includeLicenses", defaultValue = "true", required = false)
+    private Boolean includeLicenses;
+
     @Parameter(property = "excludeTypes", required = false)
     private String[] excludeTypes;
 
@@ -357,10 +360,12 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
             // If we don't already have description information, retrieve it.
             component.setDescription(project.getDescription());
         }
-        if (component.getLicenseChoice() == null || component.getLicenseChoice().getLicenses() == null || component.getLicenseChoice().getLicenses().isEmpty()) {
-            // If we don't already have license information, retrieve it.
-            if (project.getLicenses() != null) {
-                component.setLicenseChoice(resolveMavenLicenses(project.getLicenses()));
+        if (includeLicenses) {
+            if (component.getLicenseChoice() == null || component.getLicenseChoice().getLicenses() == null || component.getLicenseChoice().getLicenses().isEmpty()) {
+                // If we don't already have license information, retrieve it.
+                if (project.getLicenses() != null) {
+                    component.setLicenseChoice(resolveMavenLicenses(project.getLicenses()));
+                }
             }
         }
         if (CycloneDxSchema.Version.VERSION_10 != schemaVersion()) {
@@ -681,6 +686,7 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
             getLog().info("includeRuntimeScope    : " + includeRuntimeScope);
             getLog().info("includeTestScope       : " + includeTestScope);
             getLog().info("includeSystemScope     : " + includeSystemScope);
+            getLog().info("includeLicenses        : " + includeLicenses);
             getLog().info("------------------------------------------------------------------------");
         }
     }


### PR DESCRIPTION
The default is true. Setting it to false will entirely
omit component license information. This may be useful
for environments where spdx.org cannot be reached or
where license information is not relevant at all.