### PR TITLE
Use maven dependency analyzer to set scope automatically

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,15 +117,14 @@
             <version>3.1.1</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven.plugin-tools</groupId>
-            <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-dependency-tree</artifactId>
             <version>3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-dependency-analyzer</artifactId>
+            <version>1.11.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>


### PR DESCRIPTION
maven-dependency-analyzer use .class based analysis to classify packages into few used, untest and test sets.
This is then used to set the component scope to required or optional.

The idea is that this information could then be used by tools such as [depscan](https://github.com/AppThreat/dep-scan) to prioritize vulnerabilities based on the scope.

Key logic (excluding all glue code) is shown below:

```
// Is the artifact used?
if (usedDeclaredArtifacts.contains(artifact) || usedUndeclaredArtifacts.contains(artifact)) {
    return Component.Scope.REQUIRED;
}
// Is the artifact unused or test?
if (unusedDeclaredArtifacts.contains(artifact) || testArtifactsWithNonTestScope.contains(artifact)) {
    return Component.Scope.OPTIONAL;
}
return null;
```

