### PR TITLE
Support for exclude based on artifact id

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ Default Values
 </plugins>
 ```
 
+Excluding Projects
+-------------------
+With `makeAggregateBom` goal it is possible to exclude certain Maven Projects (artifactId) from getting included in bom.
+
+* Pass `-DexcludeTestProject=true` to skip any maven project artifactId containing the word "test"
+* Pass `-DexcludeArtifactId=comma separated id` to skip based on artifactId
+
 Notes
 -------------------
 As of v2.0.0, the default CycloneDX BOM format is v1.2 and will produce both XML and JSON. 

--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -145,6 +145,12 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo implements Contextu
     @Parameter(property = "excludeTypes", required = false)
     private String[] excludeTypes;
 
+    @Parameter(property = "excludeArtifactId", required = false)
+    protected String[] excludeArtifactId;
+
+    @Parameter(property = "excludeTestProject", defaultValue = "false", required = false)
+    protected Boolean excludeTestProject;
+
     @org.apache.maven.plugins.annotations.Component(hint = "default")
     private MavenProjectHelper mavenProjectHelper;
 
@@ -316,6 +322,24 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo implements Contextu
      */
     public String[] getExcludeTypes() {
         return excludeTypes;
+    }
+
+    /**
+     * Returns if excluded ArtifactId are defined.
+     *
+     * @return an array of excluded Artifact Id
+     */
+    public String[] getExcludeArtifactId() {
+        return excludeArtifactId;
+    }
+
+    /**
+     * Returns if project artifactId with the word test should be excluded in bom.
+     *
+     * @return true if artifactId should be excluded, otherwise false
+     */
+    protected Boolean getExcludeTestProject() {
+        return excludeTestProject;
     }
 
     /**


### PR DESCRIPTION
Enhanced `makeAggregateBom` to support exclude for certain Maven Projects (artifactId) from getting included in bom.

* Pass `-DexcludeTestProject=true` to skip any maven project artifactId containing the word "test"
* Pass `-DexcludeArtifactId=comma separated id` to skip based on artifactId

This is required for use cases where we definitely know certain modules will definitely not get included in the final package.