### PR TITLE
New goal to only analyze projects with packaging type war or ear

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Goals
 The CycloneDX Maven plugin contains the following two goals:
 * makeBom
 * makeAggregateBom
+* makePackageBom
 
 By default, the BOM(s) will be attached as an additional artifacts during a Maven install or deploy.
 

--- a/src/main/java/org/cyclonedx/maven/CycloneDxPackageMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxPackageMojo.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of CycloneDX Maven Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package org.cyclonedx.maven;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+import org.cyclonedx.model.Component;
+import org.cyclonedx.model.Dependency;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@Mojo(
+        name = "makePackageBom",
+        defaultPhase = LifecyclePhase.PACKAGE,
+        threadSafe = true,
+        aggregator = true,
+        requiresOnline = true,
+        requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME,
+        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME
+)
+public class CycloneDxPackageMojo extends BaseCycloneDxMojo {
+
+    protected boolean shouldInclude(MavenProject mavenProject) {
+        return Arrays.stream(new String[] {"war", "ear"}).anyMatch(mavenProject.getPackaging()::equals);
+    }
+
+    public void execute() throws MojoExecutionException {
+        final boolean shouldSkip = Boolean.parseBoolean(System.getProperty("cyclonedx.skip", Boolean.toString(getSkip())));
+        if (shouldSkip) {
+            getLog().info("Skipping CycloneDX");
+            return;
+        }
+
+        final Set<Component> components = new LinkedHashSet<>();
+        final Set<String> componentRefs = new LinkedHashSet<>();
+
+        Set<Dependency> dependencies = new LinkedHashSet<>();
+        for (final MavenProject mavenProject : getReactorProjects()) {
+            if (!shouldInclude(mavenProject)) {
+                continue;
+            }
+            getLog().info("Analyzing " + mavenProject.getArtifactId());
+            for (final Artifact artifact : mavenProject.getArtifacts()) {
+                if (shouldInclude(artifact)) {
+                    final Component component = convert(artifact);
+                    // ensure that only one component with the same bom-ref exists in the BOM
+                    boolean found = false;
+                    for (String s : componentRefs) {
+                        if (s != null && s.equals(component.getBomRef())) {
+                            found = true;
+                        }
+                    }
+                    if (!found) {
+                        componentRefs.add(component.getBomRef());
+                        components.add(component);
+                    }
+                }
+            }
+            if (schemaVersion().getVersion() >= 1.2) {
+                dependencies.addAll(buildDependencyGraph(componentRefs, mavenProject));
+            }
+        }
+        super.execute(components, dependencies);
+    }
+}


### PR DESCRIPTION
Reactor projects simply guarantee the order of the builds. This new goal allows only the packaging types war and ear to be considered while generating the bom file. Such a bom file can be shared externally along with the artifact without revealing other private modules that may not be included in the shared artifact.