### PR TITLE
fix Maven warning when building

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,10 +223,10 @@
                         <fileSet>
                             <directory>${project.build.directory}</directory>
                             <includes>
-                                <include>${build.finalName}.jar</include>
-                                <include>${build.finalName}.pom</include>
-                                <include>${build.finalName}-javadoc.jar</include>
-                                <include>${build.finalName}-sources.jar</include>
+                                <include>${project.build.finalName}.jar</include>
+                                <include>${project.build.finalName}.pom</include>
+                                <include>${project.build.finalName}-javadoc.jar</include>
+                                <include>${project.build.finalName}-sources.jar</include>
                                 <include>bom.json</include>
                                 <include>bom.xml</include>
                             </includes>


### PR DESCRIPTION
```
[WARNING] The expression ${build.finalName} is deprecated. Please use ${project.build.finalName} instead.
```
