### PR TITLE
Allows Mojos to detect dependencies in test scope

### DIFF
--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -744,7 +744,7 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo implements Contextu
         return null;
     }
 
-    protected void execute(Set<Component> components, Set<Dependency> dependencies, MavenProject mavenProject) throws MojoExecutionException{
+    protected void execute(Set<Component> components, Set<Dependency> dependencies, MavenProject mavenProject) throws MojoExecutionException {
         try {
             getLog().info(MESSAGE_CREATING_BOM);
             final Bom bom = new Bom();

--- a/src/main/java/org/cyclonedx/maven/CycloneDxAggregateMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxAggregateMojo.java
@@ -20,6 +20,7 @@ package org.cyclonedx.maven;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Execute;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -39,9 +40,10 @@ import java.util.Set;
         defaultPhase = LifecyclePhase.PACKAGE,
         aggregator = true,
         requiresOnline = true,
-        requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME,
-        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME
+        requiresDependencyCollection = ResolutionScope.TEST,
+        requiresDependencyResolution = ResolutionScope.TEST
 )
+@Execute( phase = LifecyclePhase.TEST_COMPILE )
 public class CycloneDxAggregateMojo extends BaseCycloneDxMojo {
 
     protected boolean shouldExclude(MavenProject mavenProject) {

--- a/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
@@ -20,6 +20,7 @@ package org.cyclonedx.maven;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Execute;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -33,9 +34,10 @@ import java.util.Set;
         name = "makeBom",
         defaultPhase = LifecyclePhase.PACKAGE,
         requiresOnline = true,
-        requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME,
-        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME
+        requiresDependencyCollection = ResolutionScope.TEST,
+        requiresDependencyResolution = ResolutionScope.TEST
 )
+@Execute( phase = LifecyclePhase.TEST_COMPILE )
 public class CycloneDxMojo extends BaseCycloneDxMojo {
 
     public void execute() throws MojoExecutionException {

--- a/src/main/java/org/cyclonedx/maven/CycloneDxPackageMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxPackageMojo.java
@@ -20,6 +20,7 @@ package org.cyclonedx.maven;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Execute;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -37,9 +38,10 @@ import java.util.Set;
         threadSafe = true,
         aggregator = true,
         requiresOnline = true,
-        requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME,
-        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME
+        requiresDependencyCollection = ResolutionScope.TEST,
+        requiresDependencyResolution = ResolutionScope.TEST
 )
+@Execute( phase = LifecyclePhase.TEST_COMPILE )
 public class CycloneDxPackageMojo extends BaseCycloneDxMojo {
 
     protected boolean shouldInclude(MavenProject mavenProject) {

--- a/src/test/java/org/cyclonedx/maven/Issue64Test.java
+++ b/src/test/java/org/cyclonedx/maven/Issue64Test.java
@@ -64,7 +64,7 @@ public class Issue64Test {
     private static void assertFileContains(File basedir, String expectedFile, String expectedContent) throws IOException {
         assertFilesPresent(basedir, expectedFile);
         String bomContents = fileRead(new File(basedir, expectedFile), true);
-        assertTrue(String.format("%s contains %s", expectedFile, expectedContent), bomContents.contains("junit"));
+        assertTrue(String.format("%s contains %s", expectedFile, expectedContent), bomContents.contains(expectedContent));
     }
 
     // source: https://github.com/takari/takari-plugin-testing-project/blob/master/takari-plugin-testing/src/main/java/io/takari/maven/testing/AbstractTestResources.java#L103

--- a/src/test/java/org/cyclonedx/maven/Issue64Test.java
+++ b/src/test/java/org/cyclonedx/maven/Issue64Test.java
@@ -1,0 +1,89 @@
+package org.cyclonedx.maven;
+
+import io.takari.maven.testing.TestResources;
+import io.takari.maven.testing.executor.MavenExecutionResult;
+import io.takari.maven.testing.executor.MavenRuntime;
+import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
+import io.takari.maven.testing.executor.MavenVersions;
+import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
+import org.apache.commons.io.FileUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.*;
+import java.util.Properties;
+
+import static io.takari.maven.testing.TestResources.assertFilesPresent;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MavenJUnitTestRunner.class)
+@MavenVersions({"3.6.3"})
+public class Issue64Test {
+
+    @Rule
+    public final TestResources resources = new TestResources(
+            "target/test-classes",
+            "target/test-classes/transformed-projects"
+    );
+
+    public final MavenRuntime verifier;
+
+    public Issue64Test(MavenRuntimeBuilder runtimeBuilder)
+            throws Exception {
+        this.verifier = runtimeBuilder.build();
+    }
+
+    @Test
+    public void testPluginWithActiviti() throws IOException, Exception {
+        File projectDirTransformed = new File(
+                "target/test-classes/transformed-projects/issue-64"
+        );
+        if (projectDirTransformed.exists()) {
+            FileUtils.cleanDirectory(projectDirTransformed);
+            projectDirTransformed.delete();
+        }
+
+        File projDir = resources.getBasedir("issue-64");
+
+        Properties props = new Properties();
+
+        props.load(Issue117Test.class.getClassLoader().getResourceAsStream("test.properties"));
+        String projectVersion = String.class.cast(props.get("project.version"));
+        verifier
+                .forProject(projDir) //
+                .withCliOption("-Dtest.input.version=" + projectVersion) // debug
+                .withCliOption("-X") // debug
+                .withCliOption("-B")
+                .execute("clean", "verify")
+                .assertErrorFreeLog();
+
+        assertFileContains(projDir, "target/bom.xml", "junit");
+    }
+
+    private static void assertFileContains(File basedir, String expectedFile, String expectedContent) throws IOException {
+        assertFilesPresent(basedir, expectedFile);
+        String bomContents = fileRead(new File(basedir, expectedFile), true);
+        assertTrue(String.format("%s contains %s", expectedFile, expectedContent), bomContents.contains("junit"));
+    }
+
+    // source: https://github.com/takari/takari-plugin-testing-project/blob/master/takari-plugin-testing/src/main/java/io/takari/maven/testing/AbstractTestResources.java#L103
+    private static String fileRead(File file, boolean normalizeEOL) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        try (BufferedReader r = new BufferedReader(new InputStreamReader(new FileInputStream(file)))) {
+            if (normalizeEOL) {
+                String str;
+                while ((str = r.readLine()) != null) {
+                    sb.append(str).append('\n');
+                }
+            } else {
+                int ch;
+                while ((ch = r.read()) != -1) {
+                    sb.append((char) ch);
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+}

--- a/src/test/resources/issue-64/pom.xml
+++ b/src/test/resources/issue-64/pom.xml
@@ -45,7 +45,7 @@
             <plugin>
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
-                <version>2.0.3</version>
+                <version>${test.input.version}</version>
                 <executions>
                     <execution>
                         <phase>verify</phase>


### PR DESCRIPTION
This _should_ fix #64.

I'm not entirely sure why this works. I stumbled across this solution while investigating #64. I was able to very easily replicate the problem, and I could also see that the `MavenProject#getArtifacts` method was not including any dependencies that have the test scope defined.

I initially tried just changing the `requiresDependencyCollection` and `requiresDependencyResolution` parameters to `ResolutionScope.TEST` but that did not appear to change anything.

When that didn't work, I started poking around the internet to see how similar packages might solve the problem, and that's when I started taking a peek at the source for the `maven-dependency-plugin` and I noticed that the Mojos in that library are [annotated with `@Execute( phase = LifecyclePhase.TEST_COMPILE )`](https://github.com/apache/maven-dependency-plugin/blob/master/src/main/java/org/apache/maven/plugins/dependency/analyze/AnalyzeReportMojo.java#L48). I tried adding that to the Mojos in this project and ... boom ... it worked.
