### PR TITLE
Add cyclonedx.verbose flag

### DIFF
--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -166,6 +166,10 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo implements Contextu
     @Parameter(property = "cyclonedx.skipAttach", defaultValue = "false", required = false)
     private boolean skipAttach = false;
 
+    @SuppressWarnings("CanBeFinal")
+    @Parameter(property = "cyclonedx.verbose", defaultValue = "true", required = false)
+    private boolean verbose = true;
+
     /**
      * Various messages sent to console.
      */
@@ -929,7 +933,7 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo implements Contextu
     }
 
     protected void logParameters() {
-        if (getLog().isInfoEnabled()) {
+        if (verbose && getLog().isInfoEnabled()) {
             getLog().info("CycloneDX: Parameters");
             getLog().info("------------------------------------------------------------------------");
             getLog().info("schemaVersion          : " + schemaVersion().getVersionString());


### PR DESCRIPTION
Default plugin output is quite verbose, especially in multi-module
builds. Add a verbose flag which can be used to suppress logging of
parameters.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>