### PR TITLE
Utilize base-version instead of version

### DIFF
--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -435,7 +435,7 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo implements Contextu
         final Component component = new Component();
         component.setGroup(artifact.getGroupId());
         component.setName(artifact.getArtifactId());
-        component.setVersion(artifact.getVersion());
+        component.setVersion(artifact.getBaseVersion());
         component.setType(Component.Type.LIBRARY);
         try {
             getLog().debug(MESSAGE_CALCULATING_HASHES);
@@ -470,7 +470,7 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo implements Contextu
                 qualifiers.put("classifier", artifact.getClassifier());
             }
         }
-        return generatePackageUrl(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion(), qualifiers, null);
+        return generatePackageUrl(artifact.getGroupId(), artifact.getArtifactId(), artifact.getBaseVersion(), qualifiers, null);
     }
 
     private String generatePackageUrl(String groupId, String artifactId, String version, TreeMap<String, String> qualifiers, String subpath) {
@@ -726,10 +726,10 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo implements Contextu
     private MavenProject readPom(InputStream in) {
         try {
             final MavenXpp3Reader mavenreader = new MavenXpp3Reader();
-            try (final InputStreamReader reader = new InputStreamReader(new BOMInputStream(in))) { 
+            try (final InputStreamReader reader = new InputStreamReader(new BOMInputStream(in))) {
                 final Model model = mavenreader.read(reader);
                 return new MavenProject(model);
-            } 
+            }
             //if you don't like BOMInputStream you can also escape the error this way:
 //            catch (XmlPullParserException xppe){
 //               if (! xppe.getMessage().startsWith("only whitespace content allowed before start tag")){


### PR DESCRIPTION
Ahoy,

I've been integrating this amazing plugin into my stack to get BOMs, however I'd noticed my dependency graph is incomplete due to a subtly in maven's distinction between base-version and version.

The dependency tree of my project looks something like this when doing a `mvn dependency:tree`:
```
my-group:my-artifact:war:1.0.0-SNAPSHOT
 +- my-group:another-artifact:pom:1.0.0-SNAPSHOT:compile
 |  \- org.springframework.boot:spring-boot:jar:2.6.7:compile
 \- org.apache.logging.log4j:log4j:jar:2.17.2:compile
```
While my BOM **does** contain all those dependencies, the dependency graph **does not** include `spring-boot` or `another-artifact`. I've spent some time tracking down the cause of the issue and found it stems from inconsistent version numbers in the purls being compared here: [BaseCycloneDxMojo.java#L898](https://github.com/CycloneDX/cyclonedx-maven-plugin/blob/d8cc991f9896cad8d464bc43e1e9df68bdff3e8c/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java#L898)

Where `componentRefs` contains a purl using a version like `1.0.0-SNAPSHOT` for `another-artifact`, the `purl` variable it's compared to has `1.0.0-20220314.010735-1`. As there's no match in the `componentRefs`, the dependency is never added and we only get a partial graph.

The reason for the mismatch between version numbers themselves is because when converting a `org.apache.maven.artifact.DefaultArtifact` to a `org.cyclonedx.model.Component` we're using [DefaultArtifact.getVersion()](https://github.com/CycloneDX/cyclonedx-maven-plugin/blob/d8cc991f9896cad8d464bc43e1e9df68bdff3e8c/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java#L438) rather than DefaultArtifact.getBaseVersion(). When the purls were originally created and added to the `componentRefs` they were created in such a way that they weren't using the timestamped version, and thus the confusion.

Since the changes the fix this seem small I've prepared a PR that gets the two purls back inline with each other.