### PR TITLE
Provide filter by group IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ With `makeAggregateBom` goal it is possible to exclude certain Maven Projects (a
 
 * Pass `-DexcludeTestProject=true` to skip any maven project artifactId containing the word "test"
 * Pass `-DexcludeArtifactId=comma separated id` to skip based on artifactId
+* Pass `-DexcludeGroupId=comma separated id` to skip based on groupId
 
 Goals
 -------------------

--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -149,6 +149,9 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo implements Contextu
     @Parameter(property = "excludeArtifactId", required = false)
     protected String[] excludeArtifactId;
 
+    @Parameter(property = "excludeGroupId", required = false)
+    protected String[] excludeGroupId;
+
     @Parameter(property = "excludeTestProject", defaultValue = "false", required = false)
     protected Boolean excludeTestProject;
 
@@ -336,6 +339,15 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo implements Contextu
      */
     public String[] getExcludeArtifactId() {
         return excludeArtifactId;
+    }
+
+    /**
+     * Returns if excluded GroupId are defined.
+     *
+     * @return an array of excluded Group Id
+     */
+    public String[] getExcludeGroupId() {
+        return excludeGroupId;
     }
 
     /**

--- a/src/main/java/org/cyclonedx/maven/CycloneDxAggregateMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxAggregateMojo.java
@@ -50,6 +50,9 @@ public class CycloneDxAggregateMojo extends BaseCycloneDxMojo {
         if (excludeArtifactId != null && excludeArtifactId.length > 0) {
             shouldExclude = Arrays.asList(excludeArtifactId).contains(mavenProject.getArtifactId());
         }
+        if (!shouldExclude && excludeGroupId != null && excludeGroupId.length > 0) {
+            shouldExclude = Arrays.asList(excludeGroupId).contains(mavenProject.getGroupId());
+        }
         if (excludeTestProject && mavenProject.getArtifactId().contains("test")) {
             shouldExclude = true;
         }


### PR DESCRIPTION
Provides a new parameter excludeGroupId to exclude all artifacts of specific group IDs, similar to excludeArtifactId.

When generating the SBOM for a multi module maven project, the generated files may contain several internal artifacts by the own organization that are not relevant for an SBOM. While excluding them one-by-one via excludeArtifactId is possible, it is cumbersome to maintain the list for a larger and changing number of artifacts, especially when automating the generation in a CI/CD pipeline.