### PR TITLE
don't use pom.distributionManagement.repository.url for BOM

### DIFF
--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -625,11 +625,6 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo implements Contextu
                     addExternalReference(ExternalReference.Type.DISTRIBUTION, project.getDistributionManagement().getDownloadUrl(), component);
                 }
             }
-            if (project.getDistributionManagement() != null && project.getDistributionManagement().getRepository() != null) {
-                if (!doesComponentHaveExternalReference(component, ExternalReference.Type.DISTRIBUTION)) {
-                    addExternalReference(ExternalReference.Type.DISTRIBUTION, project.getDistributionManagement().getRepository().getUrl(), component);
-                }
-            }
             if (project.getIssueManagement() != null && project.getIssueManagement().getUrl() != null) {
                 if (!doesComponentHaveExternalReference(component, ExternalReference.Type.ISSUE_TRACKER)) {
                     addExternalReference(ExternalReference.Type.ISSUE_TRACKER, project.getIssueManagement().getUrl(), component);


### PR DESCRIPTION
BOM requires url to download component, pom.dM.repository is for publication (e.g. OSSRH for Maven Central)

Signed-off-by: Hervé Boutemy <hboutemy@apache.org>

For example, [commons-compress 1.12 BOM](https://repo1.maven.org/maven2/org/apache/commons/commons-compress/1.22/commons-compress-1.22-cyclonedx.json) point distribution to https://repository.apache.org/service/local/staging/deploy/maven2 which is the staging area to publish to Maven Central from Apache Software Foundation