### PR TITLE
Revert "don't use pom.distributionManagement.repository.url for BOM"

### DIFF
--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -626,6 +626,11 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo implements Contextu
                     addExternalReference(ExternalReference.Type.DISTRIBUTION, project.getDistributionManagement().getDownloadUrl(), component);
                 }
             }
+            if (project.getDistributionManagement() != null && project.getDistributionManagement().getRepository() != null) {
+                if (!doesComponentHaveExternalReference(component, ExternalReference.Type.DISTRIBUTION)) {
+                    addExternalReference(ExternalReference.Type.DISTRIBUTION, project.getDistributionManagement().getRepository().getUrl(), component);
+                }
+            }
             if (project.getIssueManagement() != null && project.getIssueManagement().getUrl() != null) {
                 if (!doesComponentHaveExternalReference(component, ExternalReference.Type.ISSUE_TRACKER)) {
                     addExternalReference(ExternalReference.Type.ISSUE_TRACKER, project.getIssueManagement().getUrl(), component);


### PR DESCRIPTION
Reverts CycloneDX/cyclonedx-maven-plugin#239