### PR TITLE
don't warn with ERROR stacktrace on dependencies with bundle packaging

### DIFF
--- a/src/main/java/org/cyclonedx/maven/DefaultModelConverter.java
+++ b/src/main/java/org/cyclonedx/maven/DefaultModelConverter.java
@@ -139,8 +139,12 @@ public class DefaultModelConverter implements ModelConverter {
                     extractComponentMetadata(project, component, schemaVersion, includeLicenseText);
                 }
             } catch (ProjectBuildingException e) {
-                logger.warn("An unexpected issue occurred attempting to resolve the effective pom for  "
-                        + artifact.getGroupId() + ":" + artifact.getArtifactId() + ":" + artifact.getVersion(), e);
+                // doing same workaround as MPIR-374 https://github.com/apache/maven-project-info-reports-plugin/commit/3e139cdbafc944932407ae349da0c54fbf433e50
+                if (logger.isDebugEnabled()) {
+                    logger.warn("Unable to create Maven project for " + artifact.getId() + " from repository.", e);
+                } else {
+                    logger.warn("Unable to create Maven project for " + artifact.getId() + " from repository.");
+                }
             }
         }
         return component;

--- a/src/main/java/org/cyclonedx/maven/DefaultModelConverter.java
+++ b/src/main/java/org/cyclonedx/maven/DefaultModelConverter.java
@@ -139,7 +139,6 @@ public class DefaultModelConverter implements ModelConverter {
                     extractComponentMetadata(project, component, schemaVersion, includeLicenseText);
                 }
             } catch (ProjectBuildingException e) {
-                // doing same workaround as MPIR-374 https://github.com/apache/maven-project-info-reports-plugin/commit/3e139cdbafc944932407ae349da0c54fbf433e50
                 if (logger.isDebugEnabled()) {
                     logger.warn("Unable to create Maven project for " + artifact.getId() + " from repository.", e);
                 } else {
@@ -242,7 +241,7 @@ public class DefaultModelConverter implements ModelConverter {
     private MavenProject getEffectiveMavenProject(final Artifact artifact) throws ProjectBuildingException {
         final Artifact pomArtifact = repositorySystem.createProjectArtifact(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion());
         final ProjectBuildingResult build = mavenProjectBuilder.build(pomArtifact,
-                session.getProjectBuildingRequest().setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL)
+                session.getProjectBuildingRequest().setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL).setProcessPlugins(false)
         );
         return build.getProject();
     }

--- a/src/test/java/org/cyclonedx/maven/BundleDependencyTest.java
+++ b/src/test/java/org/cyclonedx/maven/BundleDependencyTest.java
@@ -1,0 +1,79 @@
+package org.cyclonedx.maven;
+
+import static io.takari.maven.testing.TestResources.assertFilesPresent;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
+import io.takari.maven.testing.executor.MavenVersions;
+import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
+
+/**
+ * test for https://github.com/CycloneDX/cyclonedx-maven-plugin/issues/272
+ * dependency has a bundle packaging which causes Maven's ProjectBuildingException
+ */
+@RunWith(MavenJUnitTestRunner.class)
+@MavenVersions({"3.6.3"})
+public class BundleDependencyTest extends BaseMavenVerifier {
+
+    private final static String WARN = "[WARNING] Unable to create Maven project for org.xerial.snappy:snappy-java:jar:1.1.8.4 from repository.";
+
+    public BundleDependencyTest(MavenRuntimeBuilder runtimeBuilder) throws Exception {
+        super(runtimeBuilder);
+    }
+
+    @Test
+    public void testBundleDependency() throws Exception {
+        File projDir = resources.getBasedir("bundle");
+
+        verifier
+                .forProject(projDir)
+                .withCliOption("-Dcurrent.version=" + getCurrentVersion()) // inject cyclonedx-maven-plugin version
+                .withCliOption("-B")
+                .execute("clean", "verify")
+                .assertErrorFreeLog()
+                .assertLogText(WARN);
+        // data expected from the MavenProject building is missing (was present in cyclonedx-maven-plugin 2.7.3, before https://github.com/CycloneDX/cyclonedx-maven-plugin/commit/374b3c53cbd28ffa7941d0aa7741f5b2405d83e4):
+        /*
+      "publisher" : "xerial.org",
+      "description" : "snappy-java: A fast compression/decompression library",
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/xerial/snappy-java"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/xerial/snappy-java"
+        }
+      ],
+        */
+    }
+
+    @Test
+    public void testBundleDependencyDebug() throws Exception {
+        File projDir = resources.getBasedir("bundle");
+
+        verifier
+                .forProject(projDir)
+                .withCliOption("-Dcurrent.version=" + getCurrentVersion()) // inject cyclonedx-maven-plugin version
+                .withCliOption("-B")
+                .withCliOption("-X") // debug, will print the full stacktrace with error message
+                .execute("clean", "verify")
+                .assertLogText(WARN)
+                .assertLogText("[ERROR] Unknown packaging: bundle @ line 6, column 16");
+    }
+}

--- a/src/test/java/org/cyclonedx/maven/BundleDependencyTest.java
+++ b/src/test/java/org/cyclonedx/maven/BundleDependencyTest.java
@@ -21,46 +21,8 @@ import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
 @MavenVersions({"3.6.3"})
 public class BundleDependencyTest extends BaseMavenVerifier {
 
-    private final static String WARN = "[WARNING] Unable to create Maven project for org.xerial.snappy:snappy-java:jar:1.1.8.4 from repository.";
-
     public BundleDependencyTest(MavenRuntimeBuilder runtimeBuilder) throws Exception {
         super(runtimeBuilder);
-    }
-
-    @Test
-    public void testBundleDependency() throws Exception {
-        File projDir = resources.getBasedir("bundle");
-
-        verifier
-                .forProject(projDir)
-                .withCliOption("-Dcurrent.version=" + getCurrentVersion()) // inject cyclonedx-maven-plugin version
-                .withCliOption("-B")
-                .execute("clean", "verify")
-                .assertErrorFreeLog()
-                .assertLogText(WARN);
-        // data expected from the MavenProject building is missing (was present in cyclonedx-maven-plugin 2.7.3, before https://github.com/CycloneDX/cyclonedx-maven-plugin/commit/374b3c53cbd28ffa7941d0aa7741f5b2405d83e4):
-        /*
-      "publisher" : "xerial.org",
-      "description" : "snappy-java: A fast compression/decompression library",
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "Apache-2.0",
-            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
-          }
-        }
-      ],
-      "externalReferences" : [
-        {
-          "type" : "website",
-          "url" : "https://github.com/xerial/snappy-java"
-        },
-        {
-          "type" : "vcs",
-          "url" : "https://github.com/xerial/snappy-java"
-        }
-      ],
-        */
     }
 
     @Test
@@ -71,9 +33,11 @@ public class BundleDependencyTest extends BaseMavenVerifier {
                 .forProject(projDir)
                 .withCliOption("-Dcurrent.version=" + getCurrentVersion()) // inject cyclonedx-maven-plugin version
                 .withCliOption("-B")
-                .withCliOption("-X") // debug, will print the full stacktrace with error message
+                .withCliOption("-X") // debug, will print the full stacktrace with error message if there is any model building issue
                 .execute("clean", "verify")
-                .assertLogText(WARN)
-                .assertLogText("[ERROR] Unknown packaging: bundle @ line 6, column 16");
+                .assertErrorFreeLog();
+
+        String bomContents = fileRead(new File(projDir, "target/bom.json"), true);
+        assertTrue(bomContents.contains("\"description\" : \"snappy-java: A fast compression/decompression library\""));
     }
 }

--- a/src/test/resources/bundle/pom.xml
+++ b/src/test/resources/bundle/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>issue-272</artifactId>
+    <packaging>jar</packaging>
+    <version>1.0.0</version>
+
+    <name>Issue-272: dependency with bundle packaging cause Maven ProjectBuildingException</name>
+
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency><!-- has bundle packaging https://repo.maven.apache.org/maven2/org/xerial/snappy/snappy-java/1.1.8.4/snappy-java-1.1.8.4.pom -->
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <version>1.1.8.4</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>${current.version}</version>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>makeBom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <outputFormat>json</outputFormat>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
fix #272 

1st commit avoids printing the full stack trace
this does not really fully solve the issue, but makes it less prominent:
it is done like this in other Maven plugins https://issues.apache.org/jira/browse/MPIR-374

second commit fixes the issue, as idea was found while digging into dependencies:list equivalent issue https://issues.apache.org/jira/browse/MDEP-630