### PR TITLE
document and test verbose

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Default Values
             <outputReactorProjects>true</outputReactorProjects>
             <outputFormat>all</outputFormat>
             <outputName>bom</outputName>
+            <verbose>true</verbose><!-- = ${cyclonedx.verbose} -->
         </configuration>
     </plugin>
 </plugins>

--- a/src/it/makeBom/pom.xml
+++ b/src/it/makeBom/pom.xml
@@ -64,6 +64,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <cyclonedx.verbose>false</cyclonedx.verbose><!-- override default plugin value, user still can override with CLI -Dcyclonedx.verbose -->
     </properties>
 
     <dependencies>

--- a/src/it/makeBom/verify.groovy
+++ b/src/it/makeBom/verify.groovy
@@ -11,3 +11,5 @@ File bomAggregateFileJson = new File(basedir, "target/bom-makeAggregateBom.json"
 
 assert bomAggregateFileXml.exists()
 assert bomAggregateFileJson.exists()
+
+assert ! new File(basedir, "build.log").text.contains('[INFO] CycloneDX: Parameters')

--- a/src/test/java/org/cyclonedx/maven/BundleDependencyTest.java
+++ b/src/test/java/org/cyclonedx/maven/BundleDependencyTest.java
@@ -1,10 +1,8 @@
 package org.cyclonedx.maven;
 
-import static io.takari.maven.testing.TestResources.assertFilesPresent;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/org/cyclonedx/maven/VerboseTest.java
+++ b/src/test/java/org/cyclonedx/maven/VerboseTest.java
@@ -1,0 +1,50 @@
+package org.cyclonedx.maven;
+
+import java.io.File;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
+import io.takari.maven.testing.executor.MavenVersions;
+import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
+
+/**
+ * test for https://github.com/CycloneDX/cyclonedx-maven-plugin/issues/280
+ * how to switch verbosity off by default, but let the user activate with CLI parameter
+ */
+@RunWith(MavenJUnitTestRunner.class)
+@MavenVersions({"3.6.3"})
+public class VerboseTest extends BaseMavenVerifier {
+
+    public VerboseTest(MavenRuntimeBuilder runtimeBuilder) throws Exception {
+        super(runtimeBuilder);
+    }
+
+    @Test
+    public void testVerboseOffByDefault() throws Exception {
+        File projDir = resources.getBasedir("verbose");
+
+        verifier
+                .forProject(projDir)
+                .withCliOption("-Dcurrent.version=" + getCurrentVersion()) // inject cyclonedx-maven-plugin version
+                .withCliOption("-B")
+                .execute("verify")
+                .assertErrorFreeLog()
+                .assertNoLogText("[INFO] CycloneDX: Parameters"); // check no verbose output by default given property defined in pom.xml
+    }
+
+    @Test
+    public void testVerboseWithCli() throws Exception {
+        File projDir = resources.getBasedir("verbose");
+
+        verifier
+                .forProject(projDir)
+                .withCliOption("-Dcurrent.version=" + getCurrentVersion()) // inject cyclonedx-maven-plugin version
+                .withCliOption("-B")
+                .withCliOption("-Dcyclonedx.verbose") // activate verbose with CLI parameter
+                .execute("verify")
+                .assertErrorFreeLog()
+                .assertLogText("[INFO] CycloneDX: Parameters"); // check goal verbose output
+    }
+}

--- a/src/test/resources/verbose/pom.xml
+++ b/src/test/resources/verbose/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>issue-280</artifactId>
+    <packaging>jar</packaging>
+    <version>1.0.0</version>
+
+    <name>Issue-280: make verbose off by default, that can be overridden on CLI</name>
+
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <cyclonedx.verbose>false</cyclonedx.verbose><!-- use the plugin-provided cyclonedx.verbose property to override default -->
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>${current.version}</version>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>makeBom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <outputFormat>json</outputFormat>
+                    <!-- <verbose>false</verbose> do not inject a fixed value in the plugin configuration: it could not be overridden with CLI -->
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
document particularly the recipe to turn off verbose output (that displays CycloneDX parameters) but let the user activate when he wants with CLI `mvn -Dcyclonedx.verbose package`

trick is to just define the `cyclonedx.verbose` property:
```xml
    <properties>
        <cyclonedx.verbose>false</cyclonedx.verbose>
    </properties>
```