### PR TITLE
add effective goal into BOM tool name

### DIFF
--- a/src/it/makeAggregateBom/verify.groovy
+++ b/src/it/makeAggregateBom/verify.groovy
@@ -1,17 +1,21 @@
-void assertBomFiles(String path) {
+void assertBomFiles(String path, boolean aggregate) {
     File bomFileXml = new File(basedir, path + ".xml")
     File bomFileJson = new File(basedir, path + ".json")
 
     assert bomFileXml.exists()
     assert bomFileJson.exists()
+
+    String analysis = aggregate ? "makeAggregateBom" : "makeBom"
+    assert bomFileXml.text.contains('<name>CycloneDX Maven plugin ' + analysis + '</name>')
+    assert bomFileJson.text.contains('"name" : "CycloneDX Maven plugin ' + analysis + '"')
 }
 
-assertBomFiles("target/bom") // aggregate
-assertBomFiles("api/target/bom")
-assertBomFiles("util/target/bom")
-assertBomFiles("impls/target/bom")
-assertBomFiles("impls/impl-A/target/bom")
-assertBomFiles("impls/impl-B/target/bom")
+assertBomFiles("target/bom", true) // aggregate
+assertBomFiles("api/target/bom", false)
+assertBomFiles("util/target/bom", false)
+assertBomFiles("impls/target/bom", false)
+assertBomFiles("impls/impl-A/target/bom", false)
+assertBomFiles("impls/impl-B/target/bom", false)
 
 var buildLog = new File(basedir, "build.log").text
 

--- a/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
@@ -27,6 +27,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.shared.dependency.analyzer.ProjectDependencyAnalysis;
 import org.apache.maven.shared.dependency.analyzer.ProjectDependencyAnalyzer;
 import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.cyclonedx.model.Component;
 import org.cyclonedx.model.Dependency;
 import java.util.LinkedHashSet;
@@ -69,18 +70,14 @@ public class CycloneDxMojo extends BaseCycloneDxMojo {
      * @throws MojoExecutionException in case of an error.
      */
     protected ProjectDependencyAnalyzer createProjectDependencyAnalyzer() throws MojoExecutionException {
-        final String role = ProjectDependencyAnalyzer.class.getName();
-        final String roleHint = analyzer;
         try {
-            return (ProjectDependencyAnalyzer) plexusContainer.lookup(role, roleHint);
-        }
-        catch (Exception exception) {
-            throw new MojoExecutionException("Failed to instantiate ProjectDependencyAnalyser with role " + role
-                    + " / role-hint " + roleHint, exception);
+            return (ProjectDependencyAnalyzer) plexusContainer.lookup(ProjectDependencyAnalyzer.class, analyzer);
+        } catch (ComponentLookupException cle) {
+            throw new MojoExecutionException("Failed to instantiate ProjectDependencyAnalyser with role-hint " + analyzer, cle);
         }
     }
 
-    protected boolean analyze(final Set<Component> components, final Set<Dependency> dependencies) throws MojoExecutionException {
+    protected String analyze(final Set<Component> components, final Set<Dependency> dependencies) throws MojoExecutionException {
         final Set<String> componentRefs = new LinkedHashSet<>();
         // Use default dependency analyzer
         dependencyAnalyzer = createProjectDependencyAnalyzer();
@@ -111,7 +108,7 @@ public class CycloneDxMojo extends BaseCycloneDxMojo {
         if (schemaVersion().getVersion() >= 1.2) {
             dependencies.addAll(buildDependencyGraph(null));
         }
-        return true;
+        return "makeBom";
     }
 
     /**

--- a/src/main/java/org/cyclonedx/maven/CycloneDxPackageMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxPackageMojo.java
@@ -56,7 +56,7 @@ public class CycloneDxPackageMojo extends BaseCycloneDxMojo {
         return Arrays.asList(new String[]{"war", "ear"}).contains(mavenProject.getPackaging());
     }
 
-    protected boolean analyze(Set<Component> components, Set<Dependency> dependencies) throws MojoExecutionException {
+    protected String analyze(Set<Component> components, Set<Dependency> dependencies) throws MojoExecutionException {
         final Set<String> componentRefs = new LinkedHashSet<>();
         getLog().info(MESSAGE_RESOLVING_DEPS);
 
@@ -77,6 +77,6 @@ public class CycloneDxPackageMojo extends BaseCycloneDxMojo {
                 dependencies.addAll(buildDependencyGraph(mavenProject));
             }
         }
-        return true;
+        return "makePackageBom";
     }
 }

--- a/src/main/java/org/cyclonedx/maven/DefaultModelConverter.java
+++ b/src/main/java/org/cyclonedx/maven/DefaultModelConverter.java
@@ -315,11 +315,11 @@ public class DefaultModelConverter implements ModelConverter {
         return false;
     }
 
-    public Metadata convert(final MavenProject project, String projectType, CycloneDxSchema.Version schemaVersion, boolean includeLicenseText) {
+    public Metadata convert(final MavenProject project, String analysis, String projectType, CycloneDxSchema.Version schemaVersion, boolean includeLicenseText) {
         final Tool tool = new Tool();
         final Properties properties = readPluginProperties();
         tool.setVendor(properties.getProperty("vendor"));
-        tool.setName(properties.getProperty("name"));
+        tool.setName(properties.getProperty("name") + ' ' + analysis);
         tool.setVersion(properties.getProperty("version"));
         // Attempt to add hash values from the current mojo
         final Artifact self = new DefaultArtifact(properties.getProperty("groupId"), properties.getProperty("artifactId"),

--- a/src/main/java/org/cyclonedx/maven/ModelConverter.java
+++ b/src/main/java/org/cyclonedx/maven/ModelConverter.java
@@ -48,10 +48,11 @@ public interface ModelConverter {
      * Converts a MavenProject into a Metadata object.
      *
      * @param project the MavenProject to convert
+     * @param analysis type of analysis
      * @param projectType the target CycloneDX component type
      * @param schemaVersion the target CycloneDX schema version
      * @param includeLicenseText should license text be included in bom?
      * @return a CycloneDX Metadata object
      */
-    Metadata convert(MavenProject project, String projectType, CycloneDxSchema.Version schemaVersion, boolean includeLicenseText);
+    Metadata convert(MavenProject project, String analysis, String projectType, CycloneDxSchema.Version schemaVersion, boolean includeLicenseText);
 }


### PR DESCRIPTION
having the goal name in the BOM content will help understand it the BOM is aggregate or not

root aggregate BOM describes tool as:
```json
    "tools" : [
      {
        "vendor" : "OWASP Foundation",
        "name" : "CycloneDX Maven plugin makeAggregateBom",
```

while other BOMs are not aggregate:
```json
    "tools" : [
      {
        "vendor" : "OWASP Foundation",
        "name" : "CycloneDX Maven plugin makeBom",
```
