### PR TITLE
[BUG] makeAggregateBom using CI-friendly versions: root component does not list modules as dependencies

### DIFF
--- a/src/test/java/org/cyclonedx/maven/CIFriendlyTest.java
+++ b/src/test/java/org/cyclonedx/maven/CIFriendlyTest.java
@@ -1,0 +1,43 @@
+package org.cyclonedx.maven;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
+import io.takari.maven.testing.executor.MavenVersions;
+import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
+
+/**
+ * test for https://github.com/CycloneDX/cyclonedx-maven-plugin/issues/263
+ * when makeAggregateBom using CI-friendly versions, root component does not list modules as dependencies
+ */
+@RunWith(MavenJUnitTestRunner.class)
+@MavenVersions({"3.6.3"})
+public class CIFriendlyTest extends BaseMavenVerifier {
+
+    public CIFriendlyTest(MavenRuntimeBuilder runtimeBuilder) throws Exception {
+        super(runtimeBuilder);
+    }
+
+    @Test
+    public void testCIFriendlyaggregate() throws Exception {
+        File projDir = resources.getBasedir("ci-friendly");
+
+        verifier
+                .forProject(projDir)
+                .withCliOption("-Dcurrent.version=" + getCurrentVersion()) // inject cyclonedx-maven-plugin version
+                .withCliOption("-B")
+                .withCliOption("-Drevision=ci-friendly-revision")
+                .execute("verify")
+                .assertErrorFreeLog();
+
+        String bom = fileRead(new File(projDir, "target/bom.xml"), true);
+        String rootDependencies = bom.substring(bom.indexOf("<dependency ref=\"pkg:maven/com.example/issue-263@ci-friendly-revision?type=pom"), bom.indexOf("</dependency>") + 13);
+        assertTrue("root dependencies must contain module-A@ci-friendly-revision", rootDependencies.contains("<dependency ref=\"pkg:maven/com.example/module-A@ci-friendly-revision?type=jar\"/>"));
+        assertTrue("root dependencies must contain module-B@ci-friendly-revision", rootDependencies.contains("<dependency ref=\"pkg:maven/com.example/module-B@ci-friendly-revision?type=jar\"/>"));
+    }
+}

--- a/src/test/resources/ci-friendly/moduleA/pom.xml
+++ b/src/test/resources/ci-friendly/moduleA/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>issue-263</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>module-A</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.1</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/src/test/resources/ci-friendly/moduleB/pom.xml
+++ b/src/test/resources/ci-friendly/moduleB/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>issue-263</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>module-B</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/src/test/resources/ci-friendly/pom.xml
+++ b/src/test/resources/ci-friendly/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>issue-263</artifactId>
+    <packaging>pom</packaging>
+    <version>${revision}</version>
+
+    <name>Issue-263: when makeAggregateBom using CI-friendly versions, root component does not list modules as dependencies</name>
+
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <modules>
+        <module>moduleA</module>
+        <module>moduleB</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>${current.version}</version>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>makeAggregateBom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <outputFormat>xml</outputFormat>
+                    <outputReactorProjects>false</outputReactorProjects>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
first commit is about creating a test, that fails as expected: we'll see in next steps how to fix