### PR TITLE
schema version 1.1 requires components cleanup from dependencies

### DIFF
--- a/src/main/java/org/cyclonedx/maven/CycloneDxAggregateMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxAggregateMojo.java
@@ -104,11 +104,11 @@ public class CycloneDxAggregateMojo extends CycloneDxMojo {
         getLog().info("outputReactorProjects  : " + outputReactorProjects);
     }
 
-    protected String analyze(final Set<Component> components, final Set<Dependency> dependencies) throws MojoExecutionException {
+    protected String extractComponentsAndDependencies(final Set<Component> components, final Set<Dependency> dependencies) throws MojoExecutionException {
         if (! getProject().isExecutionRoot()) {
             // non-root project: let parent class create a module-only BOM?
             if (outputReactorProjects) {
-                return super.analyze(components, dependencies);
+                return super.extractComponentsAndDependencies(components, dependencies);
             }
             getLog().info("Skipping CycloneDX on non-execution root");
             return null;
@@ -158,12 +158,13 @@ public class CycloneDxAggregateMojo extends CycloneDxMojo {
                     projectComponentRefs.add(component.getBomRef());
                 }
             }
-            if (schemaVersion().getVersion() >= 1.2) {
-                projectDependencies.addAll(buildDependencyGraph(mavenProject));
-                dependencies.addAll(projectDependencies);
-            }
+
+            projectDependencies.addAll(buildBOMDependencies(mavenProject));
+            dependencies.addAll(projectDependencies);
         }
+
         addMavenProjectsAsDependencies(reactorProjects, dependencies);
+
         return "makeAggregateBom";
     }
 

--- a/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
@@ -90,7 +90,7 @@ public class CycloneDxMojo extends BaseCycloneDxMojo {
         return null;
     }
 
-    protected String analyze(final Set<Component> components, final Set<Dependency> dependencies) throws MojoExecutionException {
+    protected String extractComponentsAndDependencies(final Set<Component> components, final Set<Dependency> dependencies) throws MojoExecutionException {
         final Set<String> componentRefs = new LinkedHashSet<>();
 
         getLog().info(MESSAGE_RESOLVING_DEPS);
@@ -111,9 +111,9 @@ public class CycloneDxMojo extends BaseCycloneDxMojo {
                 }
             }
         }
-        if (schemaVersion().getVersion() >= 1.2) {
-            dependencies.addAll(buildDependencyGraph(null));
-        }
+
+        dependencies.addAll(buildBOMDependencies(null));
+
         return "makeBom";
     }
 

--- a/src/main/java/org/cyclonedx/maven/CycloneDxPackageMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxPackageMojo.java
@@ -56,7 +56,7 @@ public class CycloneDxPackageMojo extends BaseCycloneDxMojo {
         return Arrays.asList(new String[]{"war", "ear"}).contains(mavenProject.getPackaging());
     }
 
-    protected String analyze(Set<Component> components, Set<Dependency> dependencies) throws MojoExecutionException {
+    protected String extractComponentsAndDependencies(Set<Component> components, Set<Dependency> dependencies) throws MojoExecutionException {
         final Set<String> componentRefs = new LinkedHashSet<>();
         getLog().info(MESSAGE_RESOLVING_DEPS);
 
@@ -72,10 +72,10 @@ public class CycloneDxPackageMojo extends BaseCycloneDxMojo {
                     components.add(component);
                 }
             }
-            if (schemaVersion().getVersion() >= 1.2) {
-                dependencies.addAll(buildDependencyGraph(mavenProject));
-            }
+
+            dependencies.addAll(buildBOMDependencies(mavenProject));
         }
+
         return "makePackageBom";
     }
 }

--- a/src/test/resources/bom-dependencies/pom.xml
+++ b/src/test/resources/bom-dependencies/pom.xml
@@ -71,6 +71,14 @@
                 </configuration>
             </plugin>
         </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.3.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <properties>


### PR DESCRIPTION
`validateBomDependencies(...)` method introduced inn #256 does not only validate components list but does some expected cleanup, even if dependencies are not kept into final BOM (which happens only when schema version is >= 1.2)

need to rework algorithm and method names to better match reality and get the same components list in SBOM whatever the schema version is