### PR TITLE
add a test for Maven parent dependencies in reactor

### DIFF
--- a/src/it/makeAggregateBom/verify.groovy
+++ b/src/it/makeAggregateBom/verify.groovy
@@ -55,3 +55,11 @@ assertBomEqualsNonAggregate("util/target/bom")
 assertBomEqualsNonAggregate("impls/target/bom")
 assertBomEqualsNonAggregate("impls/impl-A/target/bom")
 assertBomEqualsNonAggregate("impls/impl-B/target/bom")
+
+// dependencies for root component in makeAggregateBom is the list of modules
+String bom = new File(basedir, 'target/bom.xml').text
+String rootDependencies = bom.substring(bom.indexOf('<dependency ref="pkg:maven/org.cyclonedx.its/makeAggregateBom@1.0-SNAPSHOT?type=pom">'), bom.indexOf('</dependency>') + 13)
+assert rootDependencies.contains('<dependency ref="pkg:maven/org.cyclonedx.its/api@1.0-SNAPSHOT?type=jar"/>')
+assert rootDependencies.contains('<dependency ref="pkg:maven/org.cyclonedx.its/impls@1.0-SNAPSHOT?type=pom"/>')
+assert rootDependencies.contains('<dependency ref="pkg:maven/org.cyclonedx.its/util@1.0-SNAPSHOT?type=jar"/>')
+assert 4 == (rootDependencies =~ /<dependency ref="pkg:maven/).size()


### PR DESCRIPTION
this was added in 0eaee2fe89e6b7314e8a2f6472b103f3df562bee released in 2.5.0, but there is no test to avoid regression