### PR TITLE
streamline plugin output

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Default Values
             <outputFormat>all</outputFormat>
             <outputName>bom</outputName>
             <outputDirectory>${project.build.directory}</outputDirectory><!-- usually target, if not redefined in pom.xml -->
-            <verbose>true</verbose><!-- = ${cyclonedx.verbose} -->
+            <verbose>false</verbose><!-- = ${cyclonedx.verbose} -->
         </configuration>
     </plugin>
 </plugins>

--- a/src/it/makeAggregateBom/verify.groovy
+++ b/src/it/makeAggregateBom/verify.groovy
@@ -25,10 +25,8 @@ assert 2 == (buildLog =~ /\[INFO\] CycloneDX: Resolving Aggregated Dependencies/
 // 13 = 6 modules for main cyclonedx-makeAggregateBom execution
 //    + 1 for root module cyclonedx-makeAggregateBom-root-only execution
 //    + 6 modules for additional cyclonedx-makeBom execution
-assert 13 == (buildLog =~ /\[INFO\] CycloneDX: Writing BOM \(XML\)/).size()
-assert 13 == (buildLog =~ /\[INFO\] CycloneDX: Validating BOM \(XML\)/).size()
-assert 13 == (buildLog =~ /\[INFO\] CycloneDX: Writing BOM \(JSON\)/).size()
-assert 13 == (buildLog =~ /\[INFO\] CycloneDX: Validating BOM \(JSON\)/).size()
+assert 13 == (buildLog =~ /\[INFO\] CycloneDX: Writing and validating BOM \(XML\)/).size()
+assert 13 == (buildLog =~ /\[INFO\] CycloneDX: Writing and validating BOM \(JSON\)/).size()
 // cyclonedx-makeAggregateBom-root-only execution skips 5 non-root modules
 assert 5 == (buildLog =~ /\[INFO\] Skipping CycloneDX on non-execution root/).size()
 


### PR DESCRIPTION
by default:
```
[INFO] --- cyclonedx:2.7.6-SNAPSHOT:makeAggregateBom (cyclonedx-makeAggregateBom) @ makeAggregateBom ---
[INFO] CycloneDX: Resolving Aggregated Dependencies
[INFO] CycloneDX: Creating BOM version 1.4 with 22 component(s)
[INFO] CycloneDX: Writing and validating BOM (XML): /path/to/CycloneDX/cyclonedx-maven-plugin/target/its/makeAggregateBom/target/bom.xml
[INFO]            attaching as makeAggregateBom-1.0-SNAPSHOT-cyclonedx.xml
[INFO] CycloneDX: Writing and validating BOM (JSON): /path/to/CycloneDX/cyclonedx-maven-plugin/target/its/makeAggregateBom/target/bom.json
[WARNING] Unknown keyword additionalItems - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword
[INFO]            attaching as makeAggregateBom-1.0-SNAPSHOT-cyclonedx.json
```

notice that the WARNING is not really wanted but a separate issue (ignored until now because output was very chatty): see #305 