### PR TITLE
Ensure aggregate BOMs contain exact dependency hierarchies from each Maven module

### DIFF
--- a/src/it/makeAggregateBom/verify.groovy
+++ b/src/it/makeAggregateBom/verify.groovy
@@ -56,8 +56,8 @@ assertBomEqualsNonAggregate("impls/impl-B/target/bom")
 
 // dependencies for root component in makeAggregateBom is the list of modules
 String bom = new File(basedir, 'target/bom.xml').text
-String rootDependencies = bom.substring(bom.indexOf('<dependency ref="pkg:maven/org.cyclonedx.its/makeAggregateBom@1.0-SNAPSHOT?type=pom">'), bom.indexOf('</dependency>') + 13)
-assert rootDependencies.contains('<dependency ref="pkg:maven/org.cyclonedx.its/api@1.0-SNAPSHOT?type=jar"/>')
-assert rootDependencies.contains('<dependency ref="pkg:maven/org.cyclonedx.its/impls@1.0-SNAPSHOT?type=pom"/>')
-assert rootDependencies.contains('<dependency ref="pkg:maven/org.cyclonedx.its/util@1.0-SNAPSHOT?type=jar"/>')
+String rootDependencies = bom.substring(bom.indexOf('<dependency ref="pkg:maven/org.cyclonedx.its/makeAggregateBom@1.0-SNAPSHOT?'), bom.indexOf('</dependency>') + 13)
+assert rootDependencies.contains('<dependency ref="pkg:maven/org.cyclonedx.its/api@1.0-SNAPSHOT?')
+assert rootDependencies.contains('<dependency ref="pkg:maven/org.cyclonedx.its/impls@1.0-SNAPSHOT?')
+assert rootDependencies.contains('<dependency ref="pkg:maven/org.cyclonedx.its/util@1.0-SNAPSHOT?')
 assert 4 == (rootDependencies =~ /<dependency ref="pkg:maven/).size()

--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -26,6 +26,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
+import org.apache.maven.shared.dependency.analyzer.ProjectDependencyAnalysis;
 import org.cyclonedx.BomGeneratorFactory;
 import org.cyclonedx.CycloneDxSchema;
 import org.cyclonedx.exception.GeneratorException;
@@ -35,6 +36,7 @@ import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Component;
 import org.cyclonedx.model.Dependency;
 import org.cyclonedx.model.Metadata;
+import org.cyclonedx.model.Component.Scope;
 import org.cyclonedx.parsers.JsonParser;
 import org.cyclonedx.parsers.Parser;
 import org.cyclonedx.parsers.XmlParser;
@@ -45,8 +47,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -197,7 +200,7 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
     private ModelConverter modelConverter;
 
     @org.apache.maven.plugins.annotations.Component
-    private ProjectDependenciesConverter projectDependenciesConverter;
+    protected ProjectDependenciesConverter projectDependenciesConverter;
 
     /**
      * Various messages sent to console.
@@ -230,12 +233,13 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
     /**
      * Analyze the current Maven project to extract the BOM components list and their dependencies.
      *
-     * @param components the components set to fill
-     * @param dependencies the dependencies set to fill
+     * @param components the components map to fill
+     * @param dependencies the dependencies map to fill
+     * @param projectIdentities the map of project purls to identities for this build
      * @return the name of the analysis done to store as a BOM, or {@code null} to not save result.
      * @throws MojoExecutionException something weird happened...
      */
-    protected abstract String extractComponentsAndDependencies(Set<Component> components, Set<Dependency> dependencies) throws MojoExecutionException;
+    protected abstract String extractComponentsAndDependencies(Map<String, Component> components, Map<String, Dependency> dependencies, Map<String, String> projectIdentities) throws MojoExecutionException;
 
     public void execute() throws MojoExecutionException {
         final boolean shouldSkip = Boolean.parseBoolean(System.getProperty("cyclonedx.skip", Boolean.toString(skip)));
@@ -245,10 +249,11 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
         }
         logParameters();
 
-        final Set<Component> components = new LinkedHashSet<>();
-        final Set<Dependency> dependencies = new LinkedHashSet<>();
+        final Map<String, Component> componentMap = new LinkedHashMap<>();
+        final Map<String, Dependency> dependencyMap = new LinkedHashMap<>();
+        final Map<String, String> projectIdentities = new LinkedHashMap<>();
 
-        String analysis = extractComponentsAndDependencies(components, dependencies);
+        String analysis = extractComponentsAndDependencies(componentMap, dependencyMap, projectIdentities);
         if (analysis != null) {
             List<String> scopes = new ArrayList<>();
             if (includeCompileScope) scopes.add("compile");
@@ -258,17 +263,23 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
             if (includeTestScope) scopes.add("test");
 
             final Metadata metadata = modelConverter.convert(project, analysis + " " + String.join("+", scopes), projectType, schemaVersion(), includeLicenseText);
-            projectDependenciesConverter.cleanupBomDependencies(metadata, components, dependencies);
+            final Component rootComponent = metadata.getComponent();
+            final String rootBomRef = projectIdentities.get(rootComponent.getPurl());
+            if (rootBomRef != null) {
+                componentMap.remove(rootBomRef);
+                metadata.getComponent().setBomRef(rootBomRef);
+            }
+            projectDependenciesConverter.cleanupBomDependencies(metadata, componentMap, dependencyMap);
 
-            generateBom(analysis, metadata, components, dependencies);
+            generateBom(analysis, metadata, componentMap, dependencyMap);
         }
     }
 
-    private void generateBom(String analysis, Metadata metadata, Set<Component> components, Set<Dependency> dependencies) throws MojoExecutionException {
+    private void generateBom(String analysis, Metadata metadata, Map<String, Component> components, Map<String, Dependency> dependencies) throws MojoExecutionException {
         try {
             getLog().info(String.format(MESSAGE_CREATING_BOM, schemaVersion, components.size()));
             final Bom bom = new Bom();
-            bom.setComponents(new ArrayList<>(components));
+            bom.setComponents(new ArrayList<>(components.values()));
 
             if (schemaVersion().getVersion() >= 1.1 && includeBomSerialNumber) {
                 bom.setSerialNumber("urn:uuid:" + UUID.randomUUID());
@@ -276,7 +287,7 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
 
             if (schemaVersion().getVersion() >= 1.2) {
                 bom.setMetadata(metadata);
-                bom.setDependencies(new ArrayList<>(dependencies));
+                bom.setDependencies(new ArrayList<>(dependencies.values()));
             }
 
             /*if (schemaVersion().getVersion() >= 1.3) {
@@ -333,7 +344,7 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
         }
     }
 
-    protected Set<Dependency> extractBOMDependencies(MavenProject mavenProject) throws MojoExecutionException {
+    protected Map<String, Dependency> extractBOMDependencies(MavenProject mavenProject) throws MojoExecutionException {
         ProjectDependenciesConverter.MavenDependencyScopes include = new ProjectDependenciesConverter.MavenDependencyScopes(includeCompileScope, includeProvidedScope, includeRuntimeScope, includeTestScope, includeSystemScope);
         return projectDependenciesConverter.extractBOMDependencies(mavenProject, include, excludeTypes);
     }
@@ -377,5 +388,79 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
             logAdditionalParameters();
             getLog().info("------------------------------------------------------------------------");
         }
+    }
+
+    protected void populateComponents(final Map<String, Component> components, final Set<Artifact> artifacts, final Map<String, String> purlToIdentity, final ProjectDependencyAnalysis dependencyAnalysis) {
+        for (Artifact artifact: artifacts) {
+            final String purl = generatePackageUrl(artifact);
+            final String identity = purlToIdentity.get(purl);
+            if (identity != null) {
+                final Scope artifactScope = (dependencyAnalysis != null ? inferComponentScope(artifact, dependencyAnalysis) : null);
+                final Component component = components.get(identity);
+                if (component == null) {
+                    final Component newComponent = convert(artifact);
+                    newComponent.setBomRef(identity);
+                    newComponent.setScope(artifactScope);
+                    components.put(identity, newComponent);
+                } else {
+                    component.setScope(mergeScopes(component.getScope(), artifactScope));
+                }
+            }
+        }
+    }
+
+    /**
+     * Infer BOM component scope based on Maven project dependency analysis.
+     *
+     * @param artifact Artifact from maven project
+     * @param projectDependencyAnalysis Maven Project Dependency Analysis data
+     *
+     * @return Component.Scope - Required: If the component is used (as detected by project dependency analysis). Optional: If it is unused
+     */
+    protected Component.Scope inferComponentScope(Artifact artifact, ProjectDependencyAnalysis projectDependencyAnalysis) {
+        if (projectDependencyAnalysis == null) {
+            return null;
+        }
+
+        Set<Artifact> usedDeclaredArtifacts = projectDependencyAnalysis.getUsedDeclaredArtifacts();
+        Set<Artifact> usedUndeclaredArtifacts = projectDependencyAnalysis.getUsedUndeclaredArtifacts();
+        Set<Artifact> unusedDeclaredArtifacts = projectDependencyAnalysis.getUnusedDeclaredArtifacts();
+        Set<Artifact> testArtifactsWithNonTestScope = projectDependencyAnalysis.getTestArtifactsWithNonTestScope();
+
+        // Is the artifact used?
+        if (usedDeclaredArtifacts.contains(artifact) || usedUndeclaredArtifacts.contains(artifact)) {
+            return Component.Scope.REQUIRED;
+        }
+
+        // Is the artifact unused or test?
+        if (unusedDeclaredArtifacts.contains(artifact) || testArtifactsWithNonTestScope.contains(artifact)) {
+            return Component.Scope.OPTIONAL;
+        }
+
+        return null;
+    }
+
+    private Scope mergeScopes(final Scope existing, final Scope project) {
+        // If scope is null we don't know anything about the artifact, so we assume it's not optional.
+        // This is likely a result of the dependency analysis part being unable to run.
+        final Scope merged;
+        if (existing == null) {
+            merged = (project == Scope.REQUIRED ? Scope.REQUIRED : null);
+        } else {
+            switch (existing) {
+                case REQUIRED:
+                    merged = Scope.REQUIRED;
+                    break;
+                case OPTIONAL:
+                    merged = (project == Scope.REQUIRED || project == null ? project : existing);
+                    break;
+                case EXCLUDED:
+                    merged = (project != Scope.EXCLUDED ? project : Scope.EXCLUDED);
+                    break;
+                default:
+                    merged = project;
+            }
+        }
+        return merged;
     }
 }

--- a/src/main/java/org/cyclonedx/maven/CycloneDxAggregateMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxAggregateMojo.java
@@ -18,24 +18,19 @@
  */
 package org.cyclonedx.maven;
 
-import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.shared.dependency.analyzer.ProjectDependencyAnalysis;
 import org.cyclonedx.model.Component;
 import org.cyclonedx.model.Dependency;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Creates a CycloneDX aggregate BOM at build root (with dependencies from the whole multi-modules build), and eventually a BOM for each module.
@@ -106,11 +101,12 @@ public class CycloneDxAggregateMojo extends CycloneDxMojo {
         getLog().info("outputReactorProjects  : " + outputReactorProjects);
     }
 
-    protected String extractComponentsAndDependencies(final Set<Component> components, final Set<Dependency> dependencies) throws MojoExecutionException {
+    @Override
+    protected String extractComponentsAndDependencies(final Map<String, Component> components, final Map<String, Dependency> dependencies, final Map<String, String> projectIdentities) throws MojoExecutionException {
         if (! getProject().isExecutionRoot()) {
             // non-root project: let parent class create a module-only BOM?
             if (outputReactorProjects) {
-                return super.extractComponentsAndDependencies(components, dependencies);
+                return super.extractComponentsAndDependencies(components, dependencies, projectIdentities);
             }
             getLog().info("Skipping CycloneDX on non-execution root");
             return null;
@@ -118,15 +114,6 @@ public class CycloneDxAggregateMojo extends CycloneDxMojo {
 
         // root project: analyze and aggregate all the modules
         getLog().info((reactorProjects.size() <= 1) ? MESSAGE_RESOLVING_DEPS : MESSAGE_RESOLVING_AGGREGATED_DEPS);
-        final Set<String> componentRefs = new LinkedHashSet<>();
-
-        // Perform used/unused dependencies analysis for all projects upfront
-        final List<ProjectDependencyAnalysis> projectsDependencyAnalysis = prepareMavenDependencyAnalysis();
-
-        // Add reference to BOM metadata component.
-        // Without this, direct dependencies of the Maven project cannot be determined.
-        final Component bomComponent = convert(getProject().getArtifact());
-        componentRefs.add(bomComponent.getBomRef());
 
         for (final MavenProject mavenProject : reactorProjects) {
             if (shouldExclude(mavenProject)) {
@@ -134,32 +121,24 @@ public class CycloneDxAggregateMojo extends CycloneDxMojo {
                 continue;
             }
 
-            // Add reference to BOM metadata component.
-            // Without this, direct dependencies of the Maven project cannot be determined.
+            final Map<String, Dependency> projectDependencies = extractBOMDependencies(mavenProject);
+
+            final Map<String, String> projectPUrlToIdentity = new HashMap<>();
+            projectDependenciesConverter.normalizeDependencies(schemaVersion(), projectDependencies, projectPUrlToIdentity);
+
             final Component projectBomComponent = convert(mavenProject.getArtifact());
-            if (! mavenProject.isExecutionRoot()) {
-                // DO NOT include root project as it's already been included as a bom metadata component
-                // Also, ensure that only one project component with the same bom-ref exists in the BOM
-                if (!componentRefs.contains(projectBomComponent.getBomRef())) {
-                    components.add(projectBomComponent);
-                }
-            }
-            componentRefs.add(projectBomComponent.getBomRef());
+            final String identity = projectPUrlToIdentity.get(projectBomComponent.getPurl());
+            projectBomComponent.setBomRef(identity);
+            components.put(identity, projectBomComponent);
 
-            for (final Artifact artifact : mavenProject.getArtifacts()) {
-                final Component component = convert(artifact);
+            projectIdentities.put(projectBomComponent.getPurl(), projectBomComponent.getBomRef());
 
-                // ensure that only one component with the same bom-ref exists in the BOM
-                if (componentRefs.add(component.getBomRef())) {
-                    component.setScope(inferComponentScope(artifact, projectsDependencyAnalysis));
-                    components.add(component);
-                }
-            }
+            populateComponents(components, mavenProject.getArtifacts(), projectPUrlToIdentity, doProjectDependencyAnalysis(mavenProject));
 
-            dependencies.addAll(extractBOMDependencies(mavenProject));
+            dependencies.putAll(projectDependencies);
         }
 
-        addMavenProjectsAsParentDependencies(reactorProjects, dependencies);
+        addMavenProjectsAsParentDependencies(reactorProjects, projectIdentities, dependencies);
 
         return "makeAggregateBom";
     }
@@ -170,53 +149,23 @@ public class CycloneDxAggregateMojo extends CycloneDxMojo {
      * code dependency, but only the build reactor.
      *
      * @param reactorProjects the Maven projects from the reactor
+     * @param identities reactor project identities
      * @param dependencies all BOM dependencies found in reactor
      */
-    private void addMavenProjectsAsParentDependencies(List<MavenProject> reactorProjects, Set<Dependency> dependencies) {
-        Map<String, Dependency> dependenciesByRef = new HashMap<>();
-        dependencies.forEach(d -> dependenciesByRef.put(d.getRef(), d));
-
+    private void addMavenProjectsAsParentDependencies(List<MavenProject> reactorProjects, Map<String, String> identities, Map<String, Dependency> dependencies) {
         for (final MavenProject project: reactorProjects) {
             if (project.hasParent()) {
                 final String parentRef = generatePackageUrl(project.getParentArtifact());
-                Dependency parentDependency = dependenciesByRef.get(parentRef);
-                if (parentDependency != null) {
-                    final Dependency child = new Dependency(generatePackageUrl(project.getArtifact()));
-                    parentDependency.addDependency(child);
+                final String parentIdentity = identities.get(parentRef);
+                if (parentIdentity != null) {
+                    Dependency parentDependency = dependencies.get(parentIdentity);
+                    if (parentDependency != null) {
+                        final String projectRef = generatePackageUrl(project.getArtifact());
+                        final String projectIdentity = identities.get(projectRef);
+                        parentDependency.addDependency(new Dependency(projectIdentity));
+                    }
                 }
             }
         }
-    }
-
-    private List<ProjectDependencyAnalysis> prepareMavenDependencyAnalysis() throws MojoExecutionException {
-        final List<ProjectDependencyAnalysis> dependencyAnalysisMap = new ArrayList<>();
-        for (final MavenProject mavenProject : reactorProjects) {
-            if (shouldExclude(mavenProject)) {
-                continue;
-            }
-            ProjectDependencyAnalysis dependencyAnalysis = doProjectDependencyAnalysis(mavenProject);
-            if (dependencyAnalysis != null) {
-                dependencyAnalysisMap.add(dependencyAnalysis);
-            }
-        }
-        return dependencyAnalysisMap;
-    }
-
-    private Component.Scope inferComponentScope(Artifact artifact, List<ProjectDependencyAnalysis> projectsDependencyAnalysis) {
-        Component.Scope componentScope = null;
-        for (ProjectDependencyAnalysis dependencyAnalysis : projectsDependencyAnalysis) {
-            Component.Scope currentProjectScope = inferComponentScope(artifact, dependencyAnalysis);
-
-            // Set scope to required if the component is used in any project
-            if (Component.Scope.REQUIRED.equals(currentProjectScope)) {
-                return Component.Scope.REQUIRED;
-            }
-
-            if (componentScope == null && currentProjectScope != null) {
-                // Set optional or excluded scope
-                componentScope = currentProjectScope;
-            }
-        }
-        return componentScope;
     }
 }

--- a/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
@@ -106,6 +106,7 @@ public class CycloneDxMojo extends BaseCycloneDxMojo {
         projectIdentities.put(projectBomComponent.getPurl(), projectBomComponent.getBomRef());
 
         populateComponents(components, getProject().getArtifacts(), projectPUrlToIdentity, doProjectDependencyAnalysis(getProject()));
+
         dependencies.putAll(projectDependencies);
 
         return "makeBom";

--- a/src/main/java/org/cyclonedx/maven/CycloneDxPackageMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxPackageMojo.java
@@ -77,6 +77,7 @@ public class CycloneDxPackageMojo extends BaseCycloneDxMojo {
             projectIdentities.put(projectBomComponent.getPurl(), projectBomComponent.getBomRef());
 
             populateComponents(components, mavenProject.getArtifacts(), projectPUrlToIdentity, null);
+
             dependencies.putAll(projectDependencies);
         }
 

--- a/src/main/java/org/cyclonedx/maven/ProjectDependenciesConverter.java
+++ b/src/main/java/org/cyclonedx/maven/ProjectDependenciesConverter.java
@@ -44,7 +44,7 @@ public interface ProjectDependenciesConverter {
      * The map will be modified to reflect the distinct names, with references and the map keys
      * being updated.
      */
-    void normalizeDependencies(final CycloneDxSchema.Version schemaVersion, final Map<String, Dependency> dependencies, final Map<String, String> purlToIdentity) ;
+    void normalizeDependencies(CycloneDxSchema.Version schemaVersion, Map<String, Dependency> dependencies, Map<String, String> purlToIdentity) ;
 
     /**
      * Check consistency between BOM components and BOM dependencies, and cleanup: drop components found while walking the

--- a/src/main/java/org/cyclonedx/maven/ProjectDependenciesConverter.java
+++ b/src/main/java/org/cyclonedx/maven/ProjectDependenciesConverter.java
@@ -22,13 +22,14 @@ import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
 import org.apache.maven.artifact.resolver.filter.CumulativeScopeArtifactFilter;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
+import org.cyclonedx.CycloneDxSchema;
 import org.cyclonedx.model.Component;
 import org.cyclonedx.model.Dependency;
 import org.cyclonedx.model.Metadata;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Set;
+import java.util.Map;
 
 /**
  * Converts a Maven Project with its Maven dependencies resolution graph transformed into a SBOM dependencies list
@@ -36,13 +37,20 @@ import java.util.Set;
  */
 public interface ProjectDependenciesConverter {
 
-    Set<Dependency> extractBOMDependencies(MavenProject mavenProject, MavenDependencyScopes include, String[] excludeTypes) throws MojoExecutionException;
+    Map<String, Dependency> extractBOMDependencies(MavenProject mavenProject, MavenDependencyScopes include, String[] excludes) throws MojoExecutionException;
+
+    /**
+     * Normalize the dependencies, assigning distinct references based on their purl and dependencies.
+     * The map will be modified to reflect the distinct names, with references and the map keys
+     * being updated.
+     */
+    void normalizeDependencies(final CycloneDxSchema.Version schemaVersion, final Map<String, Dependency> dependencies, final Map<String, String> purlToIdentity) ;
 
     /**
      * Check consistency between BOM components and BOM dependencies, and cleanup: drop components found while walking the
      * Maven dependency resolution graph but that are finally not kept in the effective dependencies list.
      */
-    void cleanupBomDependencies(Metadata metadata, Set<Component> components, Set<Dependency> dependencies);
+    void cleanupBomDependencies(Metadata metadata, Map<String, Component> components, Map<String, Dependency> dependencies);
 
     public static class MavenDependencyScopes {
         public final boolean compile;

--- a/src/test/java/org/cyclonedx/maven/BomDependenciesTest.java
+++ b/src/test/java/org/cyclonedx/maven/BomDependenciesTest.java
@@ -1,23 +1,28 @@
 package org.cyclonedx.maven;
 
+import static org.cyclonedx.maven.TestUtils.containsDependency;
 import static org.cyclonedx.maven.TestUtils.getComponentNode;
+import static org.cyclonedx.maven.TestUtils.getComponentNodes;
 import static org.cyclonedx.maven.TestUtils.getComponentReferences;
 import static org.cyclonedx.maven.TestUtils.getDependencyNode;
+import static org.cyclonedx.maven.TestUtils.getDependencyNodes;
 import static org.cyclonedx.maven.TestUtils.getDependencyReferences;
+import static org.cyclonedx.maven.TestUtils.getPUrlToIdentities;
 import static org.cyclonedx.maven.TestUtils.readXML;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.w3c.dom.Document;
-import org.w3c.dom.Node;
+import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
 import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
@@ -69,6 +74,7 @@ public class BomDependenciesTest extends BaseMavenVerifier {
      */
     private void checkHiddenTestArtifacts(final File projDir) throws Exception {
         final Document bom = readXML(new File(projDir, "trustification/target/bom.xml"));
+        final Map<String, Collection<String>> purlToIdentities = getPUrlToIdentities(bom.getDocumentElement());
 
         /* BOM should contain dependency elements for
            <dependency ref="pkg:maven/com.example/shared_dependency1@1.0.0?type=jar">
@@ -83,7 +89,7 @@ public class BomDependenciesTest extends BaseMavenVerifier {
         */
         final NodeList dependenciesList = bom.getElementsByTagName("dependencies");
         assertEquals("Expected a single dependencies element", 1, dependenciesList.getLength());
-        final Node dependencies = dependenciesList.item(0);
+        final Element dependencies = (Element)dependenciesList.item(0);
 
         /*
            <dependency ref="pkg:maven/com.example/shared_dependency1@1.0.0?type=jar">
@@ -91,19 +97,17 @@ public class BomDependenciesTest extends BaseMavenVerifier {
              <dependency ref="pkg:maven/com.example/test_nested_dependency2@1.0.0?type=jar"/>
            </dependency>
         */
-        final Node sharedDependency1Node = getDependencyNode(dependencies, SHARED_DEPENDENCY1);
-        assertNotNull("Missing shared_dependency1 dependency", sharedDependency1Node);
+        final Element sharedDependency1Node = getDependencyNode(purlToIdentities, dependencies, SHARED_DEPENDENCY1);
         // Note: there are three dependencies for shared_dependency1, however one has runtime scope and should not be discovered
         final Set<String> testSharedDependency1Dependencies = getDependencyReferences(sharedDependency1Node);
         assertEquals("Invalid dependency count for shared_dependency1", 2, testSharedDependency1Dependencies.size());
-        assertTrue("Missing shared_dependency2 dependency for shared_dependency1", testSharedDependency1Dependencies.contains(SHARED_DEPENDENCY2));
-        assertTrue("Missing test_nested_dependency2 dependency for shared_dependency1", testSharedDependency1Dependencies.contains(TEST_NESTED_DEPENDENCY2));
+        containsDependency(purlToIdentities, testSharedDependency1Dependencies, SHARED_DEPENDENCY2);
+        containsDependency(purlToIdentities, testSharedDependency1Dependencies, TEST_NESTED_DEPENDENCY2);
 
         /*
            <dependency ref="pkg:maven/com.example/shared_dependency2@1.0.0?type=jar"/>
         */
-        final Node sharedDependency2Node = getDependencyNode(dependencies, SHARED_DEPENDENCY2);
-        assertNotNull("Missing shared_dependency2 dependency", sharedDependency2Node);
+        final Element sharedDependency2Node = getDependencyNode(purlToIdentities, dependencies, SHARED_DEPENDENCY2);
         final Set<String> testSharedDependency2Dependencies = getDependencyReferences(sharedDependency2Node);
         assertEquals("Invalid dependency count for shared_dependency2", 0, testSharedDependency2Dependencies.size());
 
@@ -112,17 +116,15 @@ public class BomDependenciesTest extends BaseMavenVerifier {
              <dependency ref="pkg:maven/com.example/test_nested_dependency3@1.0.0?type=jar"/>
            </dependency>
         */
-        final Node testNestedDependency2Node = getDependencyNode(dependencies, TEST_NESTED_DEPENDENCY2);
-        assertNotNull("Missing test_nested_dependency2 dependency", testNestedDependency2Node);
+        final Element testNestedDependency2Node = getDependencyNode(purlToIdentities, dependencies, TEST_NESTED_DEPENDENCY2);
         Set<String> testNestedDependency2Dependencies = getDependencyReferences(testNestedDependency2Node);
         assertEquals("Invalid dependency count for test_nested_dependency2", 1, testNestedDependency2Dependencies.size());
-        assertTrue("Missing test_nested_dependency3 dependency for test_nested_dependency2", testNestedDependency2Dependencies.contains(TEST_NESTED_DEPENDENCY3));
+        containsDependency(purlToIdentities, testNestedDependency2Dependencies, TEST_NESTED_DEPENDENCY3);
 
         /*
            <dependency ref="pkg:maven/com.example/test_nested_dependency3@1.0.0?type=jar"/>
         */
-        final Node testNestedDependency3Node = getDependencyNode(dependencies, TEST_NESTED_DEPENDENCY3);
-        assertNotNull("Missing test_nested_dependency3 dependency", testNestedDependency3Node);
+        final Element testNestedDependency3Node = getDependencyNode(purlToIdentities, dependencies, TEST_NESTED_DEPENDENCY3);
         Set<String> testNestedDependency3Dependencies = getDependencyReferences(testNestedDependency3Node);
         assertEquals("Invalid dependency count for test_nested_dependency3", 0, testNestedDependency3Dependencies.size());
     }
@@ -133,6 +135,7 @@ public class BomDependenciesTest extends BaseMavenVerifier {
      */
     private void checkHiddenRuntimeArtifacts(final File projDir) throws Exception {
         final Document bom = readXML(new File(projDir, "trustification/target/bom.xml"));
+        final Map<String, Collection<String>> purlToIdentities = getPUrlToIdentities(bom.getDocumentElement());
 
         /* BOM should contain dependency elements for
            <dependency ref="pkg:maven/com.example/shared_runtime_dependency1@1.0.0?type=jar">
@@ -142,24 +145,22 @@ public class BomDependenciesTest extends BaseMavenVerifier {
         */
         final NodeList dependenciesList = bom.getElementsByTagName("dependencies");
         assertEquals("Expected a single dependencies element", 1, dependenciesList.getLength());
-        final Node dependencies = dependenciesList.item(0);
+        final Element dependencies = (Element)dependenciesList.item(0);
 
         /*
            <dependency ref="pkg:maven/com.example/shared_runtime_dependency1@1.0.0?type=jar">
              <dependency ref="pkg:maven/com.example/shared_runtime_dependency2@1.0.0?type=jar"/>
            </dependency>
         */
-        final Node sharedRuntimeDependency1Node = getDependencyNode(dependencies, SHARED_RUNTIME_DEPENDENCY1);
-        assertNotNull("Missing shared_runtime_dependency1 dependency", sharedRuntimeDependency1Node);
+        final Element sharedRuntimeDependency1Node = getDependencyNode(purlToIdentities, dependencies, SHARED_RUNTIME_DEPENDENCY1);
         final Set<String> testSharedDependency1Dependencies = getDependencyReferences(sharedRuntimeDependency1Node);
         assertEquals("Invalid dependency count for shared_runtime_dependency1", 1, testSharedDependency1Dependencies.size());
-        assertTrue("Missing shared_runtime_dependency2 dependency for shared_runtime_dependency1", testSharedDependency1Dependencies.contains(SHARED_RUNTIME_DEPENDENCY2));
+        containsDependency(purlToIdentities, testSharedDependency1Dependencies, SHARED_RUNTIME_DEPENDENCY2);
 
         /*
            <dependency ref="pkg:maven/com.example/shared_runtime_dependency2@1.0.0?type=jar"/>
         */
-        final Node sharedRuntimeDependency2Node = getDependencyNode(dependencies, SHARED_RUNTIME_DEPENDENCY2);
-        assertNotNull("Missing shared_runtime_dependency2 dependency", sharedRuntimeDependency2Node);
+        final Element sharedRuntimeDependency2Node = getDependencyNode(purlToIdentities, dependencies, SHARED_RUNTIME_DEPENDENCY2);
         final Set<String> testSharedDependency2Dependencies = getDependencyReferences(sharedRuntimeDependency2Node);
         assertEquals("Invalid dependency count for shared_runtime_dependency2", 0, testSharedDependency2Dependencies.size());
     }
@@ -173,17 +174,17 @@ public class BomDependenciesTest extends BaseMavenVerifier {
 
         final NodeList metadataList = bom.getElementsByTagName("metadata");
         assertEquals("Expected a single metadata element", 1, metadataList.getLength());
-        final Node metadata = metadataList.item(0);
+        final Element metadata = (Element)metadataList.item(0);
         final Set<String> metadataComponentReferences = getComponentReferences(metadata);
 
         final NodeList componentsList = bom.getElementsByTagName("components");
         assertEquals("Expected a single components element", 1, componentsList.getLength());
-        final Node components = componentsList.item(0);
+        final Element components = (Element)componentsList.item(0);
         final Set<String> componentReferences = getComponentReferences(components);
 
         final NodeList dependenciesList = bom.getElementsByTagName("dependencies");
         assertEquals("Expected a single dependencies element", 1, dependenciesList.getLength());
-        final Node dependencies = dependenciesList.item(0);
+        final Element dependencies = (Element)dependenciesList.item(0);
         final Set<String> dependencyReferences = getDependencyReferences(dependencies);
 
         // Each dependency reference should have a component
@@ -194,7 +195,7 @@ public class BomDependenciesTest extends BaseMavenVerifier {
 
         // Each component reference should have a top level dependency
         for (String componentRef: componentReferences) {
-            assertNotNull("Missing top level dependency for component reference " + componentRef, getDependencyNode(dependencies, componentRef));
+            assertTrue("Missing dependency for component reference " + componentRef, dependencyReferences.contains(componentRef));
         }
     }
 
@@ -204,13 +205,13 @@ public class BomDependenciesTest extends BaseMavenVerifier {
      */
     private void checkTopLevelTestComponentsAsCompile(final File projDir) throws Exception {
         final Document bom = readXML(new File(projDir, "trustification/target/bom.xml"));
+        final Map<String, Collection<String>> purlToIdentities = getPUrlToIdentities(bom.getDocumentElement());
 
         // BOM should contain a component element for pkg:maven/com.example/test_compile_dependency@1.0.0?type=jar
         final NodeList componentsList = bom.getElementsByTagName("components");
         assertEquals("Expected a single components element", 1, componentsList.getLength());
-        final Node components = componentsList.item(0);
-        final Node testCompileDependencyNode = getComponentNode(components, TEST_COMPILE_DEPENDENCY);
-        assertNotNull("Missing test_compile_dependency component", testCompileDependencyNode);
+        final Element components = (Element)componentsList.item(0);
+        getComponentNode(purlToIdentities, components, TEST_COMPILE_DEPENDENCY);
     }
 
     /**
@@ -222,55 +223,52 @@ public class BomDependenciesTest extends BaseMavenVerifier {
         final File projDir = cleanAndBuild("bom-dependencies", new String[]{"test-jar"});
 
         final Document bom = readXML(new File(projDir, "trustification/target/bom.xml"));
+        final Map<String, Collection<String>> purlToIdentities = getPUrlToIdentities(bom.getDocumentElement());
 
         final NodeList componentsList = bom.getElementsByTagName("components");
         assertEquals("Expected a single components element", 1, componentsList.getLength());
-        final Node components = componentsList.item(0);
+        final Element components = (Element)componentsList.item(0);
 
         final NodeList dependenciesList = bom.getElementsByTagName("dependencies");
         assertEquals("Expected a single dependencies element", 1, dependenciesList.getLength());
-        final Node dependencies = dependenciesList.item(0);
+        final Element dependencies = (Element)dependenciesList.item(0);
 
         // BOM should not contain pkg:maven/com.example/type_dependency@1.0.0?classifier=tests&type=test-jar
         // component nor top level dependency because of type test-jar
-        final Node testTypeDependencyComponentNode = getComponentNode(components, TYPE_DEPENDENCY);
-        assertNull("Unexpected type_dependency component discovered in BOM", testTypeDependencyComponentNode);
-        final Node testTypeDependencyNode = getDependencyNode(dependencies, TYPE_DEPENDENCY);
-        assertNull("Unexpected type_dependency dependency discovered in BOM", testTypeDependencyNode);
+        final Collection<Element> testTypeDependencyComponentNodes = getComponentNodes(purlToIdentities, components, TYPE_DEPENDENCY);
+        assertNull("Unexpected type_dependency component discovered in BOM", testTypeDependencyComponentNodes);
+        final Collection<Element> testTypeDependencyNodes = getDependencyNodes(purlToIdentities, dependencies, TYPE_DEPENDENCY);
+        assertNull("Unexpected type_dependency dependency discovered in BOM", testTypeDependencyNodes);
 
         // BOM should contain pkg:maven/com.example/shared_type_dependency1@1.0.0?type=jar and shared_test_dependency2 and
         // pkg:maven/com.example/shared_type_dependency2@1.0.0?type=jar components/dependencies as they are referenced by dependency2
-        final Node sharedTypeDependency1ComponentNode = getComponentNode(components, SHARED_TYPE_DEPENDENCY1);
-        assertNotNull("Missing shared_type_dependency1 component", sharedTypeDependency1ComponentNode);
-        final Node sharedTypeDependency2ComponentNode = getComponentNode(components, SHARED_TYPE_DEPENDENCY2);
-        assertNotNull("Missing shared_type_dependency2 component", sharedTypeDependency2ComponentNode);
+        getComponentNode(purlToIdentities, components, SHARED_TYPE_DEPENDENCY1);
+        getComponentNode(purlToIdentities, components, SHARED_TYPE_DEPENDENCY2);
         /*
            <dependency ref="pkg:maven/com.example/shared_type_dependency1@1.0.0?type=jar">
              <dependency ref="pkg:maven/com.example/shared_type_dependency2@1.0.0?type=jar"/>
            </dependency>
            <dependency ref="pkg:maven/com.example/shared_type_dependency2@1.0.0?type=jar"/>
         */
-        final Node sharedTypeDependency1Node = getDependencyNode(dependencies, SHARED_TYPE_DEPENDENCY1);
-        assertNotNull("Missing shared_type_dependency1 dependency", sharedTypeDependency1Node);
+        final Element sharedTypeDependency1Node = getDependencyNode(purlToIdentities, dependencies, SHARED_TYPE_DEPENDENCY1);
         Set<String> sharedTypeDependency1Dependencies = getDependencyReferences(sharedTypeDependency1Node);
         assertEquals("Invalid dependency count for shared_type_dependency1", 1, sharedTypeDependency1Dependencies.size());
-        assertTrue("Missing shared_type_dependency2 dependency for shared_type_dependency1", sharedTypeDependency1Dependencies.contains(SHARED_TYPE_DEPENDENCY2));
+        containsDependency(purlToIdentities, sharedTypeDependency1Dependencies, SHARED_TYPE_DEPENDENCY2);
 
-        final Node sharedTypeDependency2Node = getDependencyNode(dependencies, SHARED_TYPE_DEPENDENCY2);
-        assertNotNull("Missing shared_type_dependency2 dependency", sharedTypeDependency2Node);
+        getDependencyNode(purlToIdentities, dependencies, SHARED_TYPE_DEPENDENCY2);
 
         // BOM should not contain pkg:maven/com.example/shared_type_dependency3@1.0.0?type=jar nor
         // pkg:maven/com.example/shared_type_dependency4@1.0.0?type=jar components/dependencies
         // as they are only referenced via type_dependency
-        final Node sharedTypeDependency3ComponentNode = getComponentNode(components, SHARED_TYPE_DEPENDENCY3);
-        assertNull("Unexpected shared_type_dependency3 component discovered in BOM", sharedTypeDependency3ComponentNode);
-        final Node sharedTypeDependency3Node = getDependencyNode(dependencies, SHARED_TYPE_DEPENDENCY3);
-        assertNull("Unexpected shared_type_dependency3 dependency discovered in BOM", sharedTypeDependency3Node);
+        final Collection<Element> sharedTypeDependency3ComponentNodes = getComponentNodes(purlToIdentities, components, SHARED_TYPE_DEPENDENCY3);
+        assertNull("Unexpected shared_type_dependency3 component discovered in BOM", sharedTypeDependency3ComponentNodes);
+        final Collection<Element> sharedTypeDependency3Nodes = getDependencyNodes(purlToIdentities, dependencies, SHARED_TYPE_DEPENDENCY3);
+        assertNull("Unexpected shared_type_dependency3 dependency discovered in BOM", sharedTypeDependency3Nodes);
 
-        final Node sharedTypeDependency4ComponentNode = getComponentNode(components, SHARED_TYPE_DEPENDENCY4);
-        assertNull("Unexpected shared_type_dependency4 component discovered in BOM", sharedTypeDependency4ComponentNode);
-        final Node sharedTypeDependency4Node = getDependencyNode(dependencies, SHARED_TYPE_DEPENDENCY4);
-        assertNull("Unexpected shared_type_dependency4 dependency discovered in BOM", sharedTypeDependency4Node);
+        final Collection<Element> sharedTypeDependency4ComponentNodes = getComponentNodes(purlToIdentities, components, SHARED_TYPE_DEPENDENCY4);
+        assertNull("Unexpected shared_type_dependency4 component discovered in BOM", sharedTypeDependency4ComponentNodes);
+        final Collection<Element> sharedTypeDependency4Nodes = getDependencyNodes(purlToIdentities, dependencies, SHARED_TYPE_DEPENDENCY4);
+        assertNull("Unexpected shared_type_dependency4 dependency discovered in BOM", sharedTypeDependency4Nodes);
     }
 
     /**
@@ -280,45 +278,43 @@ public class BomDependenciesTest extends BaseMavenVerifier {
     private void testHiddenVersionedTransitiveDependencies(final File projDir) throws Exception {
         // Note: checkExtraneousComponents will also catch missing versioned dependencies but doesn't check for transitive dependencies
         final Document bom = readXML(new File(projDir, "trustification/target/bom.xml"));
+        final Map<String, Collection<String>> purlToIdentities = getPUrlToIdentities(bom.getDocumentElement());
 
         final NodeList componentsList = bom.getElementsByTagName("components");
         assertEquals("Expected a single components element", 1, componentsList.getLength());
-        final Node components = componentsList.item(0);
+        final Element components = (Element)componentsList.item(0);
 
         final NodeList dependenciesList = bom.getElementsByTagName("dependencies");
         assertEquals("Expected a single dependencies element", 1, dependenciesList.getLength());
-        final Node dependencies = dependenciesList.item(0);
+        final Element dependencies = (Element)dependenciesList.item(0);
 
         // BOM should not contain pkg:maven/com.example/versioned_dependency@1.0.0?type=jar
-        final Node testVersionedDependency1ComponentNode = getComponentNode(components, VERSIONED_DEPENDENCY1);
-        assertNull("Unexpected versioned_dependency:1.0.0 component discovered in BOM", testVersionedDependency1ComponentNode);
-        final Node testVersionedDependency1Node = getDependencyNode(dependencies, VERSIONED_DEPENDENCY1);
-        assertNull("Unexpected versioned_dependency:1.0.0 dependency discovered in BOM", testVersionedDependency1Node);
+        final Collection<Element> testVersionedDependency1ComponentNodes = getComponentNodes(purlToIdentities, components, VERSIONED_DEPENDENCY1);
+        assertNull("Unexpected versioned_dependency:1.0.0 component discovered in BOM", testVersionedDependency1ComponentNodes);
+        final Collection<Element> testVersionedDependency1Nodes = getDependencyNodes(purlToIdentities, dependencies, VERSIONED_DEPENDENCY1);
+        assertNull("Unexpected versioned_dependency:1.0.0 dependency discovered in BOM", testVersionedDependency1Nodes);
 
         // BOM should contain pkg:maven/com.example/versioned_dependency@2.0.0?type=jar
-        final Node testVersionedDependency2ComponentNode = getComponentNode(components, VERSIONED_DEPENDENCY2);
-        assertNotNull("Missing versioned_dependency:2.0.0 component component", testVersionedDependency2ComponentNode);
+        getComponentNode(purlToIdentities, components, VERSIONED_DEPENDENCY2);
 
         /*
            <dependency ref="pkg:maven/com.example/provided_dependency@1.0.0?type=jar">
              <dependency ref="pkg:maven/com.example/versioned_dependency@2.0.0?type=jar"/>
            </dependency>
         */
-        final Node providedDependencyNode = getDependencyNode(dependencies, PROVIDED_DEPENDENCY);
-        assertNotNull("Missing provided_dependency dependency", providedDependencyNode);
+        final Element providedDependencyNode = getDependencyNode(purlToIdentities, dependencies, PROVIDED_DEPENDENCY);
         Set<String> providedDependencyDependencies = getDependencyReferences(providedDependencyNode);
         assertEquals("Invalid dependency count for provided_dependency", 1, providedDependencyDependencies.size());
-        assertTrue("Missing versioned_dependency:2.0.0 dependency for provided_dependency", providedDependencyDependencies.contains(VERSIONED_DEPENDENCY2));
+        containsDependency(purlToIdentities, providedDependencyDependencies, VERSIONED_DEPENDENCY2);
 
         /*
            <dependency ref="pkg:maven/com.example/versioned_dependency@2.0.0?type=jar">
              <dependency ref="pkg:maven/com.example/dependency1@1.0.0?type=jar"/>
            </dependency>
         */
-        final Node versionedDependencyNode = getDependencyNode(dependencies, VERSIONED_DEPENDENCY2);
-        assertNotNull("Missing versioned_dependency dependency", versionedDependencyNode);
+        final Element versionedDependencyNode = getDependencyNode(purlToIdentities, dependencies, VERSIONED_DEPENDENCY2);
         Set<String> versionedDependencyDependencies = getDependencyReferences(versionedDependencyNode);
         assertEquals("Invalid dependency count for versioned_dependency", 1, versionedDependencyDependencies.size());
-        assertTrue("Missing dependency1 dependency for versioned_dependency", versionedDependencyDependencies.contains(DEPENDENCY1));
+        containsDependency(purlToIdentities, versionedDependencyDependencies, DEPENDENCY1);
     }
 }

--- a/src/test/java/org/cyclonedx/maven/CyclicTest.java
+++ b/src/test/java/org/cyclonedx/maven/CyclicTest.java
@@ -1,23 +1,24 @@
 package org.cyclonedx.maven;
 
 import java.io.File;
+import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 
+import static org.cyclonedx.maven.TestUtils.containsDependency;
 import static org.cyclonedx.maven.TestUtils.getComponentNode;
 import static org.cyclonedx.maven.TestUtils.getDependencyNode;
 import static org.cyclonedx.maven.TestUtils.getDependencyReferences;
+import static org.cyclonedx.maven.TestUtils.getPUrlToIdentities;
 import static org.cyclonedx.maven.TestUtils.readXML;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.w3c.dom.Document;
-import org.w3c.dom.Node;
+import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
 import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
@@ -50,26 +51,24 @@ public class CyclicTest extends BaseMavenVerifier {
         }
 
         final Document bom = readXML(new File(projDir, "target/bom.xml"));
+        final Map<String, Collection<String>> purlToIdentities = getPUrlToIdentities(bom.getDocumentElement());
 
         final NodeList componentsList = bom.getElementsByTagName("components");
         assertEquals("Expected a single components element", 1, componentsList.getLength());
-        final Node components = componentsList.item(0);
+        final Element components = (Element)componentsList.item(0);
 
         final NodeList dependenciesList = bom.getElementsByTagName("dependencies");
         assertEquals("Expected a single dependencies element", 1, dependenciesList.getLength());
-        final Node dependencies = dependenciesList.item(0);
+        final Element dependencies = (Element)dependenciesList.item(0);
 
         // BOM should contain pkg:maven/com.example.cyclic/cyclic_A@1.0.0?classifier=classifier_1&type=jar
-        final Node cyclicAClassifier1ComponentNode = getComponentNode(components, CYCLIC_A_DEPENDENCY_CLASSIFIER_1);
-        assertNotNull("Missing cyclic_A:classifier_1:1.0.0 component", cyclicAClassifier1ComponentNode);
+        getComponentNode(purlToIdentities, components, CYCLIC_A_DEPENDENCY_CLASSIFIER_1);
 
         // BOM should contain pkg:maven/com.example.cyclic/cyclic_A@1.0.0?classifier=classifier_2&type=jar
-        final Node cyclicAClassifier2ComponentNode = getComponentNode(components, CYCLIC_A_DEPENDENCY_CLASSIFIER_2);
-        assertNotNull("Missing cyclic_A:classifier_2:1.0.0 component", cyclicAClassifier2ComponentNode);
+        getComponentNode(purlToIdentities, components, CYCLIC_A_DEPENDENCY_CLASSIFIER_2);
 
         // BOM should contain pkg:maven/com.example.cyclic/cyclic_A@1.0.0?classifier=classifier_3&type=jar
-        final Node cyclicAClassifier3ComponentNode = getComponentNode(components, CYCLIC_A_DEPENDENCY_CLASSIFIER_3);
-        assertNotNull("Missing cyclic_A:classifier_3:1.0.0 component", cyclicAClassifier3ComponentNode);
+        getComponentNode(purlToIdentities, components, CYCLIC_A_DEPENDENCY_CLASSIFIER_3);
 
         /*
           <dependency ref="pkg:maven/com.example.cyclic/cyclic_A@1.0.0?type=jar">
@@ -78,35 +77,31 @@ public class CyclicTest extends BaseMavenVerifier {
             <dependency ref="pkg:maven/com.example.cyclic/cyclic_A@1.0.0?classifier=classifier_3&amp;type=jar"/>
           </dependency>
         */
-        final Node cyclicADependencyNode = getDependencyNode(dependencies, CYCLIC_A_DEPENDENCY);
-        assertNotNull("Missing cyclic_A:1.0.0 dependency", cyclicADependencyNode);
+        final Element cyclicADependencyNode = getDependencyNode(purlToIdentities, dependencies, CYCLIC_A_DEPENDENCY);
         Set<String> cyclicADependencies = getDependencyReferences(cyclicADependencyNode);
         assertEquals("Invalid dependency count for cyclic_A:1.0.0", 3, cyclicADependencies.size());
-        assertTrue("Missing cyclic_A:classifier_1:1.0.0 dependency for cyclic_A:1.0.0", cyclicADependencies.contains(CYCLIC_A_DEPENDENCY_CLASSIFIER_1));
-        assertTrue("Missing cyclic_A:classifier_2:1.0.0 dependency for cyclic_A:1.0.0", cyclicADependencies.contains(CYCLIC_A_DEPENDENCY_CLASSIFIER_2));
-        assertTrue("Missing cyclic_A:classifier_3:1.0.0 dependency for cyclic_A:1.0.0", cyclicADependencies.contains(CYCLIC_A_DEPENDENCY_CLASSIFIER_3));
+        containsDependency(purlToIdentities, cyclicADependencies, CYCLIC_A_DEPENDENCY_CLASSIFIER_1);
+        containsDependency(purlToIdentities, cyclicADependencies, CYCLIC_A_DEPENDENCY_CLASSIFIER_2);
+        containsDependency(purlToIdentities, cyclicADependencies, CYCLIC_A_DEPENDENCY_CLASSIFIER_3);
 
         /*
           <dependency ref="pkg:maven/com.example.cyclic/cyclic_A@1.0.0?classifier=classifier_1&amp;type=jar"/>
          */
-        final Node cyclicAClassifier1DependencyNode = getDependencyNode(dependencies, CYCLIC_A_DEPENDENCY_CLASSIFIER_1);
-        assertNotNull("Missing cyclic_A:classifier_1:1.0.0 dependency", cyclicAClassifier1DependencyNode);
+        final Element cyclicAClassifier1DependencyNode = getDependencyNode(purlToIdentities, dependencies, CYCLIC_A_DEPENDENCY_CLASSIFIER_1);
         Set<String> cyclicAClassifier1Dependencies = getDependencyReferences(cyclicAClassifier1DependencyNode);
         assertEquals("Invalid dependency count for cyclic_A:classifier_1:1.0.0", 0, cyclicAClassifier1Dependencies.size());
 
         /*
           <dependency ref="pkg:maven/com.example.cyclic/cyclic_A@1.0.0?classifier=classifier_2&amp;type=jar"/>
          */
-        final Node cyclicAClassifier2DependencyNode = getDependencyNode(dependencies, CYCLIC_A_DEPENDENCY_CLASSIFIER_2);
-        assertNotNull("Missing cyclic_A:classifier_2:1.0.0 dependency", cyclicAClassifier2DependencyNode);
+        final Element cyclicAClassifier2DependencyNode = getDependencyNode(purlToIdentities, dependencies, CYCLIC_A_DEPENDENCY_CLASSIFIER_2);
         Set<String> cyclicAClassifier2Dependencies = getDependencyReferences(cyclicAClassifier2DependencyNode);
         assertEquals("Invalid dependency count for cyclic_A:classifier_2:1.0.0", 0, cyclicAClassifier2Dependencies.size());
 
         /*
           <dependency ref="pkg:maven/com.example.cyclic/cyclic_A@1.0.0?classifier=classifier_3&amp;type=jar"/>
          */
-        final Node cyclicAClassifier3DependencyNode = getDependencyNode(dependencies, CYCLIC_A_DEPENDENCY_CLASSIFIER_3);
-        assertNotNull("Missing cyclic_A:classifier_3:1.0.0 dependency", cyclicAClassifier3DependencyNode);
+        final Element cyclicAClassifier3DependencyNode = getDependencyNode(purlToIdentities, dependencies, CYCLIC_A_DEPENDENCY_CLASSIFIER_3);
         Set<String> cyclicAClassifier3Dependencies = getDependencyReferences(cyclicAClassifier3DependencyNode);
         assertEquals("Invalid dependency count for cyclic_A:classifier_3:1.0.0", 0, cyclicAClassifier3Dependencies.size());
     }

--- a/src/test/java/org/cyclonedx/maven/DependencyTreeTest.java
+++ b/src/test/java/org/cyclonedx/maven/DependencyTreeTest.java
@@ -1,0 +1,199 @@
+package org.cyclonedx.maven;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import static org.cyclonedx.maven.TestUtils.containsDependency;
+import static org.cyclonedx.maven.TestUtils.getComponentNode;
+import static org.cyclonedx.maven.TestUtils.getComponentNodes;
+import static org.cyclonedx.maven.TestUtils.getDependencyNode;
+import static org.cyclonedx.maven.TestUtils.getDependencyNodeByIdentity;
+import static org.cyclonedx.maven.TestUtils.getDependencyReferences;
+import static org.cyclonedx.maven.TestUtils.getPUrlToIdentities;
+import static org.cyclonedx.maven.TestUtils.readXML;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
+import io.takari.maven.testing.executor.MavenVersions;
+import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
+
+/**
+ * Fix BOM handling of conflicting dependency tree graphs
+ */
+@RunWith(MavenJUnitTestRunner.class)
+@MavenVersions({"3.6.3"})
+public class DependencyTreeTest extends BaseMavenVerifier {
+
+    private static final String EXCLUSION_DEPENDENCY_A = "pkg:maven/com.example.dependency_trees.exclusion/dependency_A@1.0.0?type=jar";
+    private static final String EXCLUSION_DEPENDENCY_B = "pkg:maven/com.example.dependency_trees.exclusion/dependency_B@1.0.0?type=jar";
+    private static final String EXCLUSION_DEPENDENCY_C = "pkg:maven/com.example.dependency_trees.exclusion/dependency_C@1.0.0?type=jar";
+    private static final String EXCLUSION_DEPENDENCY_D = "pkg:maven/com.example.dependency_trees.exclusion/dependency_D@1.0.0?type=jar";
+    private static final String EXCLUSION_DEPENDENCY_E = "pkg:maven/com.example.dependency_trees.exclusion/dependency_E@1.0.0?type=jar";
+    private static final String EXCLUSION_DEPENDENCY_F = "pkg:maven/com.example.dependency_trees.exclusion/dependency_F@1.0.0?type=jar";
+
+    private static final String MANAGED_DEPENDENCY_A = "pkg:maven/com.example.dependency_trees.managed/dependency_A@1.0.0?type=jar";
+    private static final String MANAGED_DEPENDENCY_B = "pkg:maven/com.example.dependency_trees.managed/dependency_B@1.0.0?type=jar";
+    private static final String MANAGED_DEPENDENCY_C1 = "pkg:maven/com.example.dependency_trees.managed/dependency_C@1.0.0?type=jar";
+    private static final String MANAGED_DEPENDENCY_C2 = "pkg:maven/com.example.dependency_trees.managed/dependency_C@2.0.0?type=jar";
+    private static final String MANAGED_DEPENDENCY_D = "pkg:maven/com.example.dependency_trees.managed/dependency_D@1.0.0?type=jar";
+    private static final String MANAGED_DEPENDENCY_E = "pkg:maven/com.example.dependency_trees.managed/dependency_E@1.0.0?type=jar";
+
+    public DependencyTreeTest(MavenRuntimeBuilder runtimeBuilder) throws Exception {
+        super(runtimeBuilder);
+    }
+
+    @Test
+    public void testDependencyTrees() throws Exception {
+      final File projDir = cleanAndBuild("dependency_trees", null);
+      checkExclusion(projDir);
+      checkManaged(projDir);
+    }
+
+    /**
+     * Test for alternative dependency trees generated through exclusions in the hierarchy
+     */
+    public void checkExclusion(final File projDir) throws Exception {
+      final Document bom = readXML(new File(projDir, "target/bom.xml"));
+      final Map<String, Collection<String>> purlToIdentities = getPUrlToIdentities(bom.getDocumentElement());
+
+      final NodeList componentsList = bom.getElementsByTagName("components");
+      assertEquals("Expected a single components element", 1, componentsList.getLength());
+      final Element components = (Element)componentsList.item(0);
+
+      final NodeList dependenciesList = bom.getElementsByTagName("dependencies");
+      assertEquals("Expected a single dependencies element", 1, dependenciesList.getLength());
+      final Element dependencies = (Element)dependenciesList.item(0);
+
+      /*
+        We create an aggregated BOM containing two dependency hierarchies which deviate at dependency_B.
+
+        The first graph is rooted at dependency_A and includes dependency_E as below
+
+        com.example.dependency_trees.exclusion:dependency_A:jar:1.0.0
+        \- com.example.dependency_trees.exclusion:dependency_B:jar:1.0.0:compile
+           +- com.example.dependency_trees.exclusion:dependency_C:jar:1.0.0:compile
+           |  \- com.example.dependency_trees.exclusion:dependency_D:jar:1.0.0:compile
+           \- com.example.dependency_trees.exclusion:dependency_E:jar:1.0.0:compile
+
+        The second graph is rooted at dependency_F and excludes dependency_E as below
+
+        com.example.dependency_trees.exclusion:dependency_F:jar:1.0.0
+        \- com.example.dependency_trees.exclusion:dependency_B:jar:1.0.0:compile
+           \- com.example.dependency_trees.exclusion:dependency_C:jar:1.0.0:compile
+              \- com.example.dependency_trees.exclusion:dependency_D:jar:1.0.0:compile
+       */
+
+      // Ensure there are two components for Dependency_B
+      final Collection<Element> dependencyBNodes = getComponentNodes(purlToIdentities, components, EXCLUSION_DEPENDENCY_B);
+      assertNotNull("Could not find components for dependency_B", dependencyBNodes);
+      assertEquals("Incorrect component count for dependency_B", 2, dependencyBNodes.size());
+      // Ensure there is a single component for Dependency_C
+      getComponentNode(purlToIdentities, components, EXCLUSION_DEPENDENCY_C);
+      // Ensure there is a single component for Dependency_D
+      getComponentNode(purlToIdentities, components, EXCLUSION_DEPENDENCY_D);
+
+      // Check the first graph
+
+      final Element firstDepA = getDependencyNode(purlToIdentities, dependencies, EXCLUSION_DEPENDENCY_A);
+      final Element firstDepADepB = getDependencyNode(purlToIdentities, firstDepA, EXCLUSION_DEPENDENCY_B);
+
+      final String firstDepBPUrl = firstDepADepB.getAttribute("ref");
+      final Element firstDepB = getDependencyNodeByIdentity(dependencies, firstDepBPUrl);
+      final Set<String> firstDepBDependencies = getDependencyReferences(firstDepB);
+      assertEquals("Invalid dependency count for dependency_B", 2, firstDepBDependencies.size());
+      containsDependency(purlToIdentities, firstDepBDependencies, EXCLUSION_DEPENDENCY_C);
+      containsDependency(purlToIdentities, firstDepBDependencies, EXCLUSION_DEPENDENCY_E);
+
+      // Check the second graph
+      final Element secondDepF = getDependencyNode(purlToIdentities, dependencies, EXCLUSION_DEPENDENCY_F);
+      final Element secondDepFDepB = getDependencyNode(purlToIdentities, secondDepF, EXCLUSION_DEPENDENCY_B);
+
+      final String secondDepBPUrl = secondDepFDepB.getAttribute("ref");
+      final Element secondDepB = getDependencyNodeByIdentity(dependencies, secondDepBPUrl);
+      final Set<String> secondDepBDependencies = getDependencyReferences(secondDepB);
+      assertEquals("Invalid dependency count for dependency_B", 1, secondDepBDependencies.size());
+      containsDependency(purlToIdentities, secondDepBDependencies, EXCLUSION_DEPENDENCY_C);
+
+      // Assert dependencies have different purls
+      assertNotEquals("Dependency B purls should be distinct", firstDepBPUrl, secondDepBPUrl);
+  }
+
+    /**
+     * Test for alternative dependency trees generated through managed dependencies in the hierarchy
+     */
+    public void checkManaged(final File projDir) throws Exception {
+      final Document bom = readXML(new File(projDir, "target/bom.xml"));
+      final Map<String, Collection<String>> purlToIdentities = getPUrlToIdentities(bom.getDocumentElement());
+
+      final NodeList componentsList = bom.getElementsByTagName("components");
+      assertEquals("Expected a single components element", 1, componentsList.getLength());
+      final Element components = (Element)componentsList.item(0);
+
+      final NodeList dependenciesList = bom.getElementsByTagName("dependencies");
+      assertEquals("Expected a single dependencies element", 1, dependenciesList.getLength());
+      final Element dependencies = (Element)dependenciesList.item(0);
+
+      /*
+        We create an aggregated BOM containing two dependency hierarchies which deviate at dependency_B.
+
+        The first graph is rooted at dependency_A and includes dependency_C with version 1.0.0 as below
+
+        com.example.dependency_trees.managed:dependency_A:jar:1.0.0
+        \- com.example.dependency_trees.managed:dependency_B:jar:1.0.0:compile
+           \- com.example.dependency_trees.managed:dependency_C:jar:1.0.0:compile
+              \- com.example.dependency_trees.managed:dependency_D:jar:1.0.0:compile
+
+        The second graph is rooted at dependency_E and includes dependency_C with version 2.0.0 as below
+
+        com.example.dependency_trees.managed:dependency_E:jar:1.0.0
+        \- com.example.dependency_trees.managed:dependency_B:jar:1.0.0:compile
+           \- com.example.dependency_trees.managed:dependency_C:jar:2.0.0:compile
+              \- com.example.dependency_trees.managed:dependency_D:jar:1.0.0:compile
+       */
+
+      // Ensure there are two components for Dependency_B
+      final Collection<Element> dependencyBNodes = getComponentNodes(purlToIdentities, components, MANAGED_DEPENDENCY_B);
+      assertNotNull("Could not find components for dependency_B", dependencyBNodes);
+      assertEquals("Incorrect component count for dependency_B", 2, dependencyBNodes.size());
+      // Ensure there are two components for Dependency_C
+      getComponentNode(purlToIdentities, components, MANAGED_DEPENDENCY_C1);
+      getComponentNode(purlToIdentities, components, MANAGED_DEPENDENCY_C2);
+      // Ensure there is a single component for Dependency_D
+      getComponentNode(purlToIdentities, components, MANAGED_DEPENDENCY_D);
+
+      // Check the first graph
+
+      final Element firstDepA = getDependencyNode(purlToIdentities, dependencies, MANAGED_DEPENDENCY_A);
+      final Element firstDepADepB = getDependencyNode(purlToIdentities, firstDepA, MANAGED_DEPENDENCY_B);
+
+      final String firstDepBPUrl = firstDepADepB.getAttribute("ref");
+      final Element firstDepB = getDependencyNodeByIdentity(dependencies, firstDepBPUrl);
+      final Set<String> firstDepBDependencies = getDependencyReferences(firstDepB);
+      assertEquals("Invalid dependency count for dependency_B", 1, firstDepBDependencies.size());
+      containsDependency(purlToIdentities, firstDepBDependencies, MANAGED_DEPENDENCY_C1);
+
+      // Check the second graph
+      final Element secondDepE = getDependencyNode(purlToIdentities, dependencies, MANAGED_DEPENDENCY_E);
+      final Element secondDepEDepB = getDependencyNode(purlToIdentities, secondDepE, MANAGED_DEPENDENCY_B);
+
+      final String secondDepBPUrl = secondDepEDepB.getAttribute("ref");
+      final Element secondDepB = getDependencyNodeByIdentity(dependencies, secondDepBPUrl);
+      final Set<String> secondDepBDependencies = getDependencyReferences(secondDepB);
+      assertEquals("Invalid dependency count for dependency_B", 1, secondDepBDependencies.size());
+      containsDependency(purlToIdentities, secondDepBDependencies, MANAGED_DEPENDENCY_C2);
+
+      // Assert dependencies have different purls
+      assertNotEquals("Dependency B purls should be distinct", firstDepBPUrl, secondDepBPUrl);
+  }
+}

--- a/src/test/java/org/cyclonedx/maven/Issue116Test.java
+++ b/src/test/java/org/cyclonedx/maven/Issue116Test.java
@@ -38,7 +38,7 @@ public class Issue116Test extends BaseMavenVerifier {
 
         // assert commons-lang3 has appeared in the dependency graph multiple times
         String bomContents = fileRead(new File(projDir, "target/bom.xml"), true);
-        int matches = StringUtils.countMatches(bomContents, "<dependency ref=\"pkg:maven/org.apache.commons/commons-lang3@3.1?type=jar\"/>");
+        int matches = StringUtils.countMatches(bomContents, "<dependency ref=\"pkg:maven/org.apache.commons/commons-lang3@3.1?");
         assertEquals(4, matches); // 1 for the definition, 3 for each of its usages
     }
 }

--- a/src/test/java/org/cyclonedx/maven/Issue284Test.java
+++ b/src/test/java/org/cyclonedx/maven/Issue284Test.java
@@ -1,22 +1,24 @@
 package org.cyclonedx.maven;
 
 import java.io.File;
+import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 
-import static org.cyclonedx.maven.TestUtils.getComponentNode;
+import static org.cyclonedx.maven.TestUtils.containsDependency;
+import static org.cyclonedx.maven.TestUtils.getComponentNodes;
 import static org.cyclonedx.maven.TestUtils.getDependencyNode;
 import static org.cyclonedx.maven.TestUtils.getDependencyReferences;
+import static org.cyclonedx.maven.TestUtils.getPUrlToIdentities;
 import static org.cyclonedx.maven.TestUtils.readXML;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.w3c.dom.Document;
-import org.w3c.dom.Node;
+import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
 import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
@@ -47,39 +49,38 @@ public class Issue284Test extends BaseMavenVerifier {
         final File projDir = cleanAndBuild("issue-284", null);
 
         final Document bom = readXML(new File(projDir, "issue284/target/bom.xml"));
+        final Map<String, Collection<String>> purlToIdentities = getPUrlToIdentities(bom.getDocumentElement());
 
         final NodeList componentsList = bom.getElementsByTagName("components");
         assertEquals("Expected a single components element", 1, componentsList.getLength());
-        final Node components = componentsList.item(0);
+        final Element components = (Element)componentsList.item(0);
 
         final NodeList dependenciesList = bom.getElementsByTagName("dependencies");
         assertEquals("Expected a single dependencies element", 1, dependenciesList.getLength());
-        final Node dependencies = dependenciesList.item(0);
+        final Element dependencies = (Element)dependenciesList.item(0);
 
         // BOM should not contain pkg:maven/com.example/issue284_provided_dependency@1.0.0?type=jar
-        final Node testIssue284ProvidedDependency1ComponentNode = getComponentNode(components, ISSUE284_PROVIDED_DEPENDENCY);
-        assertNull("Unexpected provided_dependency:1.0.0 component discovered in BOM", testIssue284ProvidedDependency1ComponentNode);
+        final Collection<Element> testIssue284ProvidedDependency1ComponentNodes = getComponentNodes(purlToIdentities, components, ISSUE284_PROVIDED_DEPENDENCY);
+        assertNull("Unexpected provided_dependency:1.0.0 component discovered in BOM", testIssue284ProvidedDependency1ComponentNodes);
 
         /*
            <dependency ref="pkg:maven/com.example/issue284_dependency2@1.0.0?type=jar">
              <dependency ref="pkg:maven/com.example/issue284_shared_dependency1@1.0.0?type=jar"/>
            </dependency>
         */
-        final Node issue284Dependency2Node = getDependencyNode(dependencies, ISSUE284_DEPENDENCY2);
-        assertNotNull("Missing issue284_dependency2 dependency", issue284Dependency2Node);
+        final Element issue284Dependency2Node = getDependencyNode(purlToIdentities, dependencies, ISSUE284_DEPENDENCY2);
         Set<String> issue284Dependency2Dependencies = getDependencyReferences(issue284Dependency2Node);
         assertEquals("Invalid dependency count for issue284_dependency2", 1, issue284Dependency2Dependencies.size());
-        assertTrue("Missing issue284_shared_dependency1 dependency for issue284_dependency2", issue284Dependency2Dependencies.contains(ISSUE284_SHARED_DEPENDENCY1));
+        containsDependency(purlToIdentities, issue284Dependency2Dependencies, ISSUE284_SHARED_DEPENDENCY1);
 
         /*
            <dependency ref="pkg:maven/com.example/issue284_shared_dependency1@1.0.0?type=jar">
              <dependency ref="pkg:maven/com.example/issue284_shared_dependency2@1.0.0?type=jar"/>
            </dependency>
          */
-        final Node issue284SharedDependency1Node = getDependencyNode(dependencies, ISSUE284_SHARED_DEPENDENCY1);
-        assertNotNull("Missing issue284_shared_dependency1 dependency", issue284SharedDependency1Node);
+        final Element issue284SharedDependency1Node = getDependencyNode(purlToIdentities, dependencies, ISSUE284_SHARED_DEPENDENCY1);
         Set<String> issue284SharedDependency1Dependencies = getDependencyReferences(issue284SharedDependency1Node);
         assertEquals("Invalid dependency count for issue284_shared_dependency1", 1, issue284SharedDependency1Dependencies.size());
-        assertTrue("Missing issue284_shared_dependency2 dependency for issue284_shared_dependency1", issue284SharedDependency1Dependencies.contains(ISSUE284_SHARED_DEPENDENCY2));
+        containsDependency(purlToIdentities, issue284SharedDependency1Dependencies, ISSUE284_SHARED_DEPENDENCY2);
     }
 }

--- a/src/test/java/org/cyclonedx/maven/RuntimeTest.java
+++ b/src/test/java/org/cyclonedx/maven/RuntimeTest.java
@@ -1,20 +1,22 @@
 package org.cyclonedx.maven;
 
 import java.io.File;
+import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 
+import static org.cyclonedx.maven.TestUtils.containsDependency;
 import static org.cyclonedx.maven.TestUtils.getDependencyNode;
 import static org.cyclonedx.maven.TestUtils.getDependencyReferences;
+import static org.cyclonedx.maven.TestUtils.getPUrlToIdentities;
 import static org.cyclonedx.maven.TestUtils.readXML;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.w3c.dom.Document;
-import org.w3c.dom.Node;
+import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
 import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
@@ -35,7 +37,7 @@ public class RuntimeTest extends BaseMavenVerifier {
     private static final String RUNTIME_PROVIDED = "pkg:maven/com.example/runtime_provided@1.0.0?type=jar";
     private static final String RUNTIME_TEST = "pkg:maven/com.example/runtime_test@1.0.0?type=jar";
     private static final String RUNTIME_SHARED_DEPENDENCY1 = "pkg:maven/com.example/runtime_shared_dependency1@1.0.0?type=jar";
-    private static final Object RUNTIME_SHARED_DEPENDENCY2 = "pkg:maven/com.example/runtime_shared_dependency2@1.0.0?type=jar";
+    private static final String RUNTIME_SHARED_DEPENDENCY2 = "pkg:maven/com.example/runtime_shared_dependency2@1.0.0?type=jar";
 
     public RuntimeTest(MavenRuntimeBuilder runtimeBuilder) throws Exception {
         super(runtimeBuilder);
@@ -51,10 +53,11 @@ public class RuntimeTest extends BaseMavenVerifier {
 
     public void checkRuntimeCompile(final File projDir) throws Exception {
         final Document bom = readXML(new File(projDir, "runtime_compile/target/bom.xml"));
+        final Map<String, Collection<String>> purlToIdentities = getPUrlToIdentities(bom.getDocumentElement());
 
         final NodeList dependenciesList = bom.getElementsByTagName("dependencies");
         assertEquals("Expected a single dependencies element", 1, dependenciesList.getLength());
-        final Node dependencies = dependenciesList.item(0);
+        final Element dependencies = (Element)dependenciesList.item(0);
 
         /*
            <dependency ref="pkg:maven/com.example/runtime_compile@1.0.0?type=jar">
@@ -62,18 +65,16 @@ public class RuntimeTest extends BaseMavenVerifier {
              <dependency ref="pkg:maven/com.example/runtime_dependency@1.0.0?type=jar"/>
            </dependency>
          */
-        final Node runtimeCompileNode = getDependencyNode(dependencies, RUNTIME_COMPILE);
-        assertNotNull("Missing runtime_compile dependency", runtimeCompileNode);
+        final Element runtimeCompileNode = getDependencyNode(purlToIdentities, dependencies, RUNTIME_COMPILE);
         Set<String> runtimeCompileDependencies = getDependencyReferences(runtimeCompileNode);
         assertEquals("Invalid dependency count for runtime_compile", 2, runtimeCompileDependencies.size());
-        assertTrue("Missing runtime_runtime_dependency dependency for runtime_compile", runtimeCompileDependencies.contains(RUNTIME_RUNTIME_DEPENDENCY));
-        assertTrue("Missing runtime_dependency dependency for runtime_compile", runtimeCompileDependencies.contains(RUNTIME_DEPENDENCY));
+        containsDependency(purlToIdentities, runtimeCompileDependencies, RUNTIME_RUNTIME_DEPENDENCY);
+        containsDependency(purlToIdentities, runtimeCompileDependencies, RUNTIME_DEPENDENCY);
 
         /*
            <dependency ref="pkg:maven/com.example/runtime_runtime_dependency@1.0.0?type=jar"/>
          */
-        final Node runtimeRuntimeDependencyNode = getDependencyNode(dependencies, RUNTIME_RUNTIME_DEPENDENCY);
-        assertNotNull("Missing runtime_runtime_dependency dependency", runtimeRuntimeDependencyNode);
+        final Element runtimeRuntimeDependencyNode = getDependencyNode(purlToIdentities, dependencies, RUNTIME_RUNTIME_DEPENDENCY);
         Set<String> runtimeRuntimeDependencyDependencies = getDependencyReferences(runtimeRuntimeDependencyNode);
         assertEquals("Invalid dependency count for runtime_runtime_dependency", 0, runtimeRuntimeDependencyDependencies.size());
 
@@ -82,30 +83,29 @@ public class RuntimeTest extends BaseMavenVerifier {
              <dependency ref="pkg:maven/com.example/runtime_shared_dependency1@1.0.0?type=jar"/>
            </dependency>
          */
-        final Node runtimeDependencyNode = getDependencyNode(dependencies, RUNTIME_DEPENDENCY);
-        assertNotNull("Missing runtime_dependency dependency", runtimeDependencyNode);
+        final Element runtimeDependencyNode = getDependencyNode(purlToIdentities, dependencies, RUNTIME_DEPENDENCY);
         Set<String> runtimeDependencyDependencies = getDependencyReferences(runtimeDependencyNode);
         assertEquals("Invalid dependency count for runtime_dependency", 1, runtimeDependencyDependencies.size());
-        assertTrue("Missing runtime_shared_dependency1 dependency for runtime_dependency", runtimeDependencyDependencies.contains(RUNTIME_SHARED_DEPENDENCY1));
+        containsDependency(purlToIdentities, runtimeDependencyDependencies, RUNTIME_SHARED_DEPENDENCY1);
 
         /*
            <dependency ref="pkg:maven/com.example/runtime_shared_dependency1@1.0.0?type=jar">
              <dependency ref="pkg:maven/com.example/runtime_shared_dependency2@1.0.0?type=jar"/>
            </dependency>
          */
-        final Node runtimeSharedDependency1Node = getDependencyNode(dependencies, RUNTIME_SHARED_DEPENDENCY1);
-        assertNotNull("Missing runtime_shared_dependency1 dependency", runtimeSharedDependency1Node);
+        final Element runtimeSharedDependency1Node = getDependencyNode(purlToIdentities, dependencies, RUNTIME_SHARED_DEPENDENCY1);
         Set<String> runtimeSharedDependency1Dependencies = getDependencyReferences(runtimeSharedDependency1Node);
         assertEquals("Invalid dependency count for runtime_shared_dependency1", 1, runtimeSharedDependency1Dependencies.size());
-        assertTrue("Missing runtime_shared_dependency2 dependency for runtime_shared_dependency1", runtimeSharedDependency1Dependencies.contains(RUNTIME_SHARED_DEPENDENCY2));
+        containsDependency(purlToIdentities, runtimeSharedDependency1Dependencies, RUNTIME_SHARED_DEPENDENCY2);
     }
 
     public void checkRuntimeProvided(final File projDir) throws Exception {
         final Document bom = readXML(new File(projDir, "runtime_provided/target/bom.xml"));
+        final Map<String, Collection<String>> purlToIdentities = getPUrlToIdentities(bom.getDocumentElement());
 
         final NodeList dependenciesList = bom.getElementsByTagName("dependencies");
         assertEquals("Expected a single dependencies element", 1, dependenciesList.getLength());
-        final Node dependencies = dependenciesList.item(0);
+        final Element dependencies = (Element)dependenciesList.item(0);
 
         /*
            <dependency ref="pkg:maven/com.example/runtime_provided@1.0.0?type=jar">
@@ -113,39 +113,37 @@ public class RuntimeTest extends BaseMavenVerifier {
              <dependency ref="pkg:maven/com.example/runtime_runtime_dependency@1.0.0?type=jar"/>
            </dependency>
          */
-        final Node runtimeProvidedNode = getDependencyNode(dependencies, RUNTIME_PROVIDED);
-        assertNotNull("Missing runtime_provided dependency", runtimeProvidedNode);
+        final Element runtimeProvidedNode = getDependencyNode(purlToIdentities, dependencies, RUNTIME_PROVIDED);
         Set<String> runtimeProvidedDependencies = getDependencyReferences(runtimeProvidedNode);
         assertEquals("Invalid dependency count for runtime_provided", 2, runtimeProvidedDependencies.size());
-        assertTrue("Missing runtime_shared_dependency1 dependency for runtime_provided", runtimeProvidedDependencies.contains(RUNTIME_SHARED_DEPENDENCY1));
-        assertTrue("Missing runtime_runtime_dependency dependency for runtime_provided", runtimeProvidedDependencies.contains(RUNTIME_RUNTIME_DEPENDENCY));
+        containsDependency(purlToIdentities, runtimeProvidedDependencies, RUNTIME_SHARED_DEPENDENCY1);
+        containsDependency(purlToIdentities, runtimeProvidedDependencies, RUNTIME_RUNTIME_DEPENDENCY);
 
         /*
            <dependency ref="pkg:maven/com.example/runtime_shared_dependency1@1.0.0?type=jar">
              <dependency ref="pkg:maven/com.example/runtime_shared_dependency2@1.0.0?type=jar"/>
            </dependency>
          */
-        final Node runtimeSharedDependency1Node = getDependencyNode(dependencies, RUNTIME_SHARED_DEPENDENCY1);
-        assertNotNull("Missing runtime_shared_dependency1 dependency", runtimeSharedDependency1Node);
+        final Element runtimeSharedDependency1Node = getDependencyNode(purlToIdentities, dependencies, RUNTIME_SHARED_DEPENDENCY1);
         Set<String> runtimeSharedDependency1Dependencies = getDependencyReferences(runtimeSharedDependency1Node);
         assertEquals("Invalid dependency count for runtime_shared_dependency1", 1, runtimeSharedDependency1Dependencies.size());
-        assertTrue("Missing runtime_shared_dependency2 dependency for runtime_shared_dependency1", runtimeSharedDependency1Dependencies.contains(RUNTIME_SHARED_DEPENDENCY2));
+        containsDependency(purlToIdentities, runtimeSharedDependency1Dependencies, RUNTIME_SHARED_DEPENDENCY2);
 
         /*
            <dependency ref="pkg:maven/com.example/runtime_runtime_dependency@1.0.0?type=jar"/>
          */
-        final Node runtimeRuntimeDependencyNode = getDependencyNode(dependencies, RUNTIME_RUNTIME_DEPENDENCY);
-        assertNotNull("Missing runtime_runtime_dependency dependency", runtimeRuntimeDependencyNode);
+        final Element runtimeRuntimeDependencyNode = getDependencyNode(purlToIdentities, dependencies, RUNTIME_RUNTIME_DEPENDENCY);
         Set<String> runtimeRuntimeDependencyDependencies = getDependencyReferences(runtimeRuntimeDependencyNode);
         assertEquals("Invalid dependency count for runtime_runtime_dependency", 0, runtimeRuntimeDependencyDependencies.size());
     }
 
     public void checkRuntimeTest(final File projDir) throws Exception {
         final Document bom = readXML(new File(projDir, "runtime_test/target/bom.xml"));
+        final Map<String, Collection<String>> purlToIdentities = getPUrlToIdentities(bom.getDocumentElement());
 
         final NodeList dependenciesList = bom.getElementsByTagName("dependencies");
         assertEquals("Expected a single dependencies element", 1, dependenciesList.getLength());
-        final Node dependencies = dependenciesList.item(0);
+        final Element dependencies = (Element)dependenciesList.item(0);
 
         /*
            <dependency ref="pkg:maven/com.example/runtime_test@1.0.0?type=jar">
@@ -153,29 +151,26 @@ public class RuntimeTest extends BaseMavenVerifier {
              <dependency ref="pkg:maven/com.example/runtime_runtime_dependency@1.0.0?type=jar"/>
            </dependency>
          */
-        final Node runtimeTestNode = getDependencyNode(dependencies, RUNTIME_TEST);
-        assertNotNull("Missing runtime_test dependency", runtimeTestNode);
+        final Element runtimeTestNode = getDependencyNode(purlToIdentities, dependencies, RUNTIME_TEST);
         Set<String> runtimeTestDependencies = getDependencyReferences(runtimeTestNode);
         assertEquals("Invalid dependency count for runtime_test", 2, runtimeTestDependencies.size());
-        assertTrue("Missing runtime_shared_dependency1 dependency for runtime_test", runtimeTestDependencies.contains(RUNTIME_SHARED_DEPENDENCY1));
-        assertTrue("Missing runtime_runtime_dependency dependency for runtime_test", runtimeTestDependencies.contains(RUNTIME_RUNTIME_DEPENDENCY));
+        containsDependency(purlToIdentities, runtimeTestDependencies, RUNTIME_SHARED_DEPENDENCY1);
+        containsDependency(purlToIdentities, runtimeTestDependencies, RUNTIME_RUNTIME_DEPENDENCY);
 
         /*
            <dependency ref="pkg:maven/com.example/runtime_shared_dependency1@1.0.0?type=jar">
              <dependency ref="pkg:maven/com.example/runtime_shared_dependency2@1.0.0?type=jar"/>
            </dependency>
          */
-        final Node runtimeSharedDependency1Node = getDependencyNode(dependencies, RUNTIME_SHARED_DEPENDENCY1);
-        assertNotNull("Missing runtime_shared_dependency1 dependency", runtimeSharedDependency1Node);
+        final Element runtimeSharedDependency1Node = getDependencyNode(purlToIdentities, dependencies, RUNTIME_SHARED_DEPENDENCY1);
         Set<String> runtimeSharedDependency1Dependencies = getDependencyReferences(runtimeSharedDependency1Node);
         assertEquals("Invalid dependency count for runtime_shared_dependency1", 1, runtimeSharedDependency1Dependencies.size());
-        assertTrue("Missing runtime_shared_dependency2 dependency for runtime_shared_dependency1", runtimeSharedDependency1Dependencies.contains(RUNTIME_SHARED_DEPENDENCY2));
+        containsDependency(purlToIdentities, runtimeSharedDependency1Dependencies, RUNTIME_SHARED_DEPENDENCY2);
 
         /*
            <dependency ref="pkg:maven/com.example/runtime_runtime_dependency@1.0.0?type=jar"/>
          */
-        final Node runtimeRuntimeDependencyNode = getDependencyNode(dependencies, RUNTIME_RUNTIME_DEPENDENCY);
-        assertNotNull("Missing runtime_runtime_dependency dependency", runtimeRuntimeDependencyNode);
+        final Element runtimeRuntimeDependencyNode = getDependencyNode(purlToIdentities, dependencies, RUNTIME_RUNTIME_DEPENDENCY);
         Set<String> runtimeRuntimeDependencyDependencies = getDependencyReferences(runtimeRuntimeDependencyNode);
         assertEquals("Invalid dependency count for runtime_runtime_dependency", 0, runtimeRuntimeDependencyDependencies.size());
     }

--- a/src/test/java/org/cyclonedx/maven/TestUtils.java
+++ b/src/test/java/org/cyclonedx/maven/TestUtils.java
@@ -2,7 +2,11 @@ package org.cyclonedx.maven;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -10,58 +14,113 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 class TestUtils {
-    static Node getDependencyNode(final Node dependencies, final String ref) {
-        return getChildElement(dependencies, ref, "dependency", "ref");
+    static Element getDependencyNode(final Map<String, Collection<String>> purlToIdentities, final Element dependencies, final String purl) throws Exception {
+        int numElements = 0;
+        Collection<Element> elements = getDependencyNodes(purlToIdentities, dependencies, purl);
+        if (elements != null) {
+            numElements = elements.size();
+            if (numElements == 1) {
+                return elements.iterator().next();
+            }
+        }
+        throw new Exception("Expected a single dependency for purl " + purl + ", found " + numElements + " dependencies");
     }
 
-    static Node getComponentNode(final Node components, final String ref) {
-        return getChildElement(components, ref, "component", "bom-ref");
+    static Element getComponentNode(final Map<String, Collection<String>> purlToIdentities, final Element components, final String purl) throws Exception {
+        int numElements = 0;
+        Collection<Element> elements = getComponentNodes(purlToIdentities, components, purl);
+        if (elements != null) {
+            numElements = elements.size();
+            if (numElements == 1) {
+                return elements.iterator().next();
+            }
+        }
+        throw new Exception("Expected a single component for purl " + purl + ", found " + numElements + " components");
     }
 
-    private static Node getChildElement(final Node parent, final String ref, final String elementName, final String attrName) {
+    static Collection<Element> getDependencyNodes(final Map<String, Collection<String>> purlToIdentities, final Element dependencies, final String purl) {
+        return getChildElements(purlToIdentities, dependencies, purl, "dependency", "ref");
+    }
+
+    static Collection<Element> getComponentNodes(final Map<String, Collection<String>> purlToIdentities, final Element components, final String purl) {
+        return getChildElements(purlToIdentities, components, purl, "component", "bom-ref");
+    }
+
+    static Element getDependencyNodeByIdentity(final Element dependencies, final String identity) throws Exception {
+        int numElements = 0;
+        Collection<Element> elements = getChildElementsByIdentity(dependencies, Arrays.asList(identity), "dependency", "ref");
+        if (elements != null) {
+            numElements = elements.size();
+            if (numElements == 1) {
+                return elements.iterator().next();
+            }
+        }
+        throw new Exception("Expected a single dependency for identity " + identity + ", found " + numElements + " dependencies");
+    }
+
+    static Element getComponentNodeByIdentity(final Element components, final String identity) throws Exception {
+        int numElements = 0;
+        Collection<Element> elements =  getChildElementsByIdentity(components, Arrays.asList(identity), "component", "bom-ref");
+        if (elements != null) {
+            numElements = elements.size();
+            if (numElements == 1) {
+                return elements.iterator().next();
+            }
+        }
+        throw new Exception("Expected a single compoennt for identity " + identity + ", found " + numElements + " components");
+    }
+
+    private static Collection<Element> getChildElements(final Map<String, Collection<String>> purlToIdentities, final Element parent, final String purl, final String elementName, final String attrName) {
+        final Collection<String> identities = purlToIdentities.get(purl);
+        return getChildElementsByIdentity(parent, identities, elementName, attrName);
+    }
+
+    private static Collection<Element> getChildElementsByIdentity(final Element parent, final Collection<String> identities, final String elementName, final String attrName) {
+        if (identities == null) {
+            return null;
+        }
+        final Collection<Element> childElements = new HashSet<>();
+
         final NodeList children = parent.getChildNodes();
         final int numChildNodes = children.getLength();
         for (int index = 0 ; index < numChildNodes ; index++) {
             final Node child = children.item(index);
             if ((child.getNodeType() == Node.ELEMENT_NODE) && elementName.equals(child.getNodeName())) {
                 final Node refNode = child.getAttributes().getNamedItem(attrName);
-                if (ref.equals(refNode.getNodeValue())) {
-                    return child;
+                if (identities.contains(refNode.getNodeValue())) {
+                    childElements.add((Element)child);
                 }
             }
         }
-        return null;
+        return childElements;
     }
 
-    static Set<String> getComponentReferences(final Node parent) {
+    static Set<String> getComponentReferences(final Element parent) {
         return getReferences(null, parent, "component", "bom-ref");
     }
 
-    static Set<String> getDependencyReferences(final Node parent) {
+    static Set<String> getDependencyReferences(final Element parent) {
         return getReferences(null, parent, "dependency", "ref");
     }
 
-    private static Set<String> getReferences(Set<String> references, final Node rootNode, final String elementName, final String attrName) {
+    private static Set<String> getReferences(Set<String> references, final Element root, final String elementName, final String attrName) {
         if (references == null) {
             references = new HashSet<>();
         }
-        final NodeList children = rootNode.getChildNodes();
-        final int numChildNodes = children.getLength();
-        for (int index = 0 ; index < numChildNodes ; index++) {
-            final Node child = children.item(index);
-            if (child.getNodeType() == Node.ELEMENT_NODE) {
-                if (elementName.equals(child.getNodeName())) {
-                    final Node refNode = child.getAttributes().getNamedItem(attrName);
-                    if (refNode != null) {
-                        references.add(refNode.getNodeValue());
-                    }
-                }
-                getReferences(references, child, elementName, attrName);
+
+        final NodeList components = root.getElementsByTagName(elementName);
+        final int numComponents = components.getLength();
+        for (int index = 0 ; index < numComponents ; index++) {
+            final Element component = (Element) components.item(index);
+            final String value = component.getAttribute(attrName);
+            if (value != null) {
+                references.add(value);
             }
         }
         return references;
@@ -76,5 +135,36 @@ class TestUtils {
 
         final DocumentBuilder builder = factory.newDocumentBuilder();
         return builder.parse(file);
+    }
+
+    static Map<String, Collection<String>> getPUrlToIdentities(final Element root) {
+        final Map<String, Collection<String>> purlToIdentities = new HashMap<>();
+        final NodeList components = root.getElementsByTagName("component");
+        for (int index = 0 ; index < components.getLength() ; index++) {
+            final Element component = (Element)components.item(index);
+            final String bomRef = component.getAttribute("bom-ref");
+            final String purl = component.getElementsByTagName("purl").item(0).getTextContent();
+            final Collection<String> identities = purlToIdentities.get(purl);
+            if (identities != null) {
+                identities.add(bomRef);
+            } else {
+                final Collection<String> newIdentities = new HashSet<>();
+                newIdentities.add(bomRef);
+                purlToIdentities.put(purl, newIdentities);
+            }
+        }
+        return purlToIdentities;
+    }
+
+    static boolean containsDependency(final Map<String, Collection<String>> purlToIdentities, final Set<String> dependencies, final String purl) throws Exception {
+        final Collection<String> identities = purlToIdentities.get(purl);
+        int numIdentities = 0;
+        if (identities != null) {
+            numIdentities = identities.size();
+            if (numIdentities == 1) {
+                return dependencies.contains(identities.iterator().next());
+            }
+        }
+        throw new Exception("Expected a single identity for purl " + purl + ", found " + numIdentities + " identities");
     }
 }

--- a/src/test/resources/dependency_trees/exclusion/dependency_A/pom.xml
+++ b/src/test/resources/dependency_trees/exclusion/dependency_A/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example.dependency_trees.exclusion</groupId>
+        <artifactId>exclusion_parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>dependency_A</artifactId>
+
+    <name>Dependency A</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.example.dependency_trees.exclusion</groupId>
+            <artifactId>dependency_B</artifactId>
+            <version>1.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/test/resources/dependency_trees/exclusion/dependency_B/pom.xml
+++ b/src/test/resources/dependency_trees/exclusion/dependency_B/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example.dependency_trees.exclusion</groupId>
+        <artifactId>exclusion_parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>dependency_B</artifactId>
+
+    <name>Dependency B</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.example.dependency_trees.exclusion</groupId>
+            <artifactId>dependency_C</artifactId>
+            <version>1.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.example.dependency_trees.exclusion</groupId>
+            <artifactId>dependency_E</artifactId>
+            <version>1.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/test/resources/dependency_trees/exclusion/dependency_C/pom.xml
+++ b/src/test/resources/dependency_trees/exclusion/dependency_C/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example.dependency_trees.exclusion</groupId>
+        <artifactId>exclusion_parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>dependency_C</artifactId>
+
+    <name>Dependency C</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.example.dependency_trees.exclusion</groupId>
+            <artifactId>dependency_D</artifactId>
+            <version>1.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/test/resources/dependency_trees/exclusion/dependency_D/pom.xml
+++ b/src/test/resources/dependency_trees/exclusion/dependency_D/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example.dependency_trees.exclusion</groupId>
+        <artifactId>exclusion_parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>dependency_D</artifactId>
+
+    <name>Dependency D</name>
+</project>

--- a/src/test/resources/dependency_trees/exclusion/dependency_E/pom.xml
+++ b/src/test/resources/dependency_trees/exclusion/dependency_E/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example.dependency_trees.exclusion</groupId>
+        <artifactId>exclusion_parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>dependency_E</artifactId>
+
+    <name>Dependency E</name>
+</project>

--- a/src/test/resources/dependency_trees/exclusion/dependency_F/pom.xml
+++ b/src/test/resources/dependency_trees/exclusion/dependency_F/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example.dependency_trees.exclusion</groupId>
+        <artifactId>exclusion_parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>dependency_F</artifactId>
+
+    <name>Dependency F</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.example.dependency_trees.exclusion</groupId>
+                <artifactId>dependency_B</artifactId>
+                <version>1.0.0</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.example.dependency_trees.exclusion</groupId>
+                        <artifactId>dependency_E</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.example.dependency_trees.exclusion</groupId>
+            <artifactId>dependency_B</artifactId>
+            <version>1.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/test/resources/dependency_trees/exclusion/pom.xml
+++ b/src/test/resources/dependency_trees/exclusion/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example.dependency_trees.exclusion</groupId>
+    <artifactId>exclusion_parent</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0.0</version>
+
+    <name>Exclusion Tests Parent</name>
+
+    <modules>
+        <module>dependency_A</module>
+        <module>dependency_B</module>
+        <module>dependency_C</module>
+        <module>dependency_D</module>
+        <module>dependency_E</module>
+        <module>dependency_F</module>
+    </modules>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>
+

--- a/src/test/resources/dependency_trees/managed/dependency_A/pom.xml
+++ b/src/test/resources/dependency_trees/managed/dependency_A/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example.dependency_trees.managed</groupId>
+        <artifactId>managed_parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>dependency_A</artifactId>
+
+    <name>Dependency A</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.example.dependency_trees.managed</groupId>
+            <artifactId>dependency_B</artifactId>
+            <version>1.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/test/resources/dependency_trees/managed/dependency_B/pom.xml
+++ b/src/test/resources/dependency_trees/managed/dependency_B/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example.dependency_trees.managed</groupId>
+        <artifactId>managed_parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>dependency_B</artifactId>
+
+    <name>Dependency B</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.example.dependency_trees.managed</groupId>
+            <artifactId>dependency_C</artifactId>
+            <version>1.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/test/resources/dependency_trees/managed/dependency_C1/pom.xml
+++ b/src/test/resources/dependency_trees/managed/dependency_C1/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example.dependency_trees.managed</groupId>
+        <artifactId>managed_parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>dependency_C</artifactId>
+
+    <name>Dependency C</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.example.dependency_trees.managed</groupId>
+            <artifactId>dependency_D</artifactId>
+            <version>1.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/test/resources/dependency_trees/managed/dependency_C2/pom.xml
+++ b/src/test/resources/dependency_trees/managed/dependency_C2/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example.dependency_trees.managed</groupId>
+        <artifactId>managed_parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>dependency_C</artifactId>
+    <version>2.0.0</version>
+
+    <name>Dependency C</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.example.dependency_trees.managed</groupId>
+            <artifactId>dependency_D</artifactId>
+            <version>1.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/test/resources/dependency_trees/managed/dependency_D/pom.xml
+++ b/src/test/resources/dependency_trees/managed/dependency_D/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example.dependency_trees.managed</groupId>
+        <artifactId>managed_parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>dependency_D</artifactId>
+
+    <name>Dependency D</name>
+</project>

--- a/src/test/resources/dependency_trees/managed/dependency_E/pom.xml
+++ b/src/test/resources/dependency_trees/managed/dependency_E/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example.dependency_trees.managed</groupId>
+        <artifactId>managed_parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>dependency_E</artifactId>
+
+    <name>Dependency E</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.example.dependency_trees.managed</groupId>
+                <artifactId>dependency_C</artifactId>
+                <version>2.0.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.example.dependency_trees.managed</groupId>
+            <artifactId>dependency_B</artifactId>
+            <version>1.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/test/resources/dependency_trees/managed/pom.xml
+++ b/src/test/resources/dependency_trees/managed/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example.dependency_trees.managed</groupId>
+    <artifactId>managed_parent</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0.0</version>
+
+    <name>Managed Dependency Tests Parent</name>
+
+    <modules>
+        <module>dependency_A</module>
+        <module>dependency_B</module>
+        <module>dependency_C1</module>
+        <module>dependency_C2</module>
+        <module>dependency_D</module>
+        <module>dependency_E</module>
+    </modules>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>
+

--- a/src/test/resources/dependency_trees/pom.xml
+++ b/src/test/resources/dependency_trees/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example.dependency_trees</groupId>
+    <artifactId>dependency_trees_parent</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0.0</version>
+
+    <name>Dependency Trees Tests Parent</name>
+
+    <modules>
+        <module>exclusion</module>
+        <module>managed</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>${current.version}</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>makeAggregateBom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <projectType>library</projectType>
+                    <schemaVersion>1.3</schemaVersion>
+                    <includeBomSerialNumber>true</includeBomSerialNumber>
+                    <includeCompileScope>true</includeCompileScope>
+                    <includeProvidedScope>true</includeProvidedScope>
+                    <includeRuntimeScope>false</includeRuntimeScope>
+                    <includeSystemScope>false</includeSystemScope>
+                    <includeTestScope>false</includeTestScope>
+                    <includeLicenseText>false</includeLicenseText>
+                    <outputFormat>xml</outputFormat>
+                </configuration>
+            </plugin>
+        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.3.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>


### PR DESCRIPTION
see #310 for more details

> prior to this PR, the dependency tree would only include one of the dependency trees. After this PR is applied, the SBOM will contain multiple components for dependency_B, with the same purl but differing bom-refs, and each component will be included in a separate dependency tree.
