### PR TITLE
[logging] Re-use 'verbose' to reduce logging output during runs

### DIFF
--- a/src/it/makeAggregateBom/pom.xml
+++ b/src/it/makeAggregateBom/pom.xml
@@ -89,6 +89,9 @@
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
                 <version>@project.version@</version>
+                <configuration>
+                    <verbose>true</verbose>
+                </configuration>
                 <!-- intentionally use default configuration -->
                 <executions>
                     <execution>

--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -206,7 +206,7 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
      */
     @SuppressWarnings("CanBeFinal")
     @Parameter(property = "cyclonedx.verbose", defaultValue = "false", required = false)
-    private boolean verbose = false;
+    protected boolean verbose = false;
 
     /**
      * Timestamp for reproducible output archive entries, either formatted as ISO 8601
@@ -361,7 +361,11 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
 
     private void generateBom(String analysis, Metadata metadata, List<Component> components, List<Dependency> dependencies) throws MojoExecutionException {
         try {
-            getLog().info(String.format(MESSAGE_CREATING_BOM, schemaVersion, components.size()));
+            if (verbose) {
+                getLog().info(String.format(MESSAGE_CREATING_BOM, schemaVersion, components.size()));
+            } else {
+                getLog().debug(String.format(MESSAGE_CREATING_BOM, schemaVersion, components.size()));
+            }
             final Bom bom = new Bom();
             bom.setComponents(components);
 
@@ -447,7 +451,11 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
     private void saveBomToFile(String bomString, String extension, Parser bomParser) throws IOException, MojoExecutionException {
         final File bomFile = new File(outputDirectory, outputName + "." + extension);
 
-        getLog().info(String.format(MESSAGE_WRITING_BOM, extension.toUpperCase(), bomFile.getAbsolutePath()));
+        if (verbose) {
+            getLog().info(String.format(MESSAGE_WRITING_BOM, extension.toUpperCase(), bomFile.getAbsolutePath()));
+        } else {
+            getLog().debug(String.format(MESSAGE_WRITING_BOM, extension.toUpperCase(), bomFile.getAbsolutePath()));
+        }
         FileUtils.write(bomFile, bomString, StandardCharsets.UTF_8, false);
 
         if (!bomParser.isValid(bomFile, schemaVersion())) {
@@ -455,7 +463,11 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
         }
 
         if (!skipAttach) {
-            getLog().info(String.format(MESSAGE_ATTACHING_BOM, project.getArtifactId(), project.getVersion(), extension));
+            if (verbose) {
+                getLog().info(String.format(MESSAGE_ATTACHING_BOM, project.getArtifactId(), project.getVersion(), extension));
+            } else {
+                getLog().debug(String.format(MESSAGE_ATTACHING_BOM, project.getArtifactId(), project.getVersion(), extension));
+            }
             mavenProjectHelper.attachArtifact(project, extension, "cyclonedx", bomFile);
         }
     }

--- a/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
@@ -118,7 +118,11 @@ public class CycloneDxMojo extends BaseCycloneDxMojo {
     }
 
     protected String extractComponentsAndDependencies(final Set<String> topLevelComponents, final Map<String, Component> components, final Map<String, Dependency> dependencies) throws MojoExecutionException {
-        getLog().info(MESSAGE_RESOLVING_DEPS);
+        if (verbose) {
+            getLog().info(MESSAGE_RESOLVING_DEPS);
+        } else {
+            getLog().debug(MESSAGE_RESOLVING_DEPS);
+        }
 
         final BomDependencies bomDependencies = extractBOMDependencies(getProject());
         final Map<String, Dependency> projectDependencies = bomDependencies.getDependencies();

--- a/src/main/java/org/cyclonedx/maven/CycloneDxPackageMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxPackageMojo.java
@@ -55,13 +55,21 @@ public class CycloneDxPackageMojo extends BaseCycloneDxMojo {
     }
 
     protected String extractComponentsAndDependencies(Set<String> topLevelComponents, Map<String, Component> components, Map<String, Dependency> dependencies) throws MojoExecutionException {
-        getLog().info(MESSAGE_RESOLVING_DEPS);
+        if (verbose) {
+            getLog().info(MESSAGE_RESOLVING_DEPS);
+        } else {
+            getLog().debug(MESSAGE_RESOLVING_DEPS);
+        }
 
         for (final MavenProject mavenProject : reactorProjects) {
             if (!shouldInclude(mavenProject)) {
                 continue;
             }
-            getLog().info("Analyzing " + mavenProject.getArtifactId());
+            if (verbose) {
+                getLog().info("Analyzing " + mavenProject.getArtifactId());
+            } else {
+                getLog().debug("Analyzing " + mavenProject.getArtifactId());
+            }
 
             final BomDependencies bomDependencies = extractBOMDependencies(mavenProject);
             final Map<String, Dependency> projectDependencies = bomDependencies.getDependencies();


### PR DESCRIPTION
I did look around and did not see any reports of wanting this data entirely hidden.  This PR doesn't solve needs completely and probably needs another field to handle this as I'm mixing its usage with verbose.  Maybe something with logging level here might do it.

Currently logging on this plugin is mostly in 'info' mode making it incredibility chatty with zero value in the data posted.  This becomes worse during multi module builds that is aggregated and constantly replacing attached data.  This PR won't solve all instances but will make a good attempt at reducing the output.

After reuse of 'verbose' here, when false which is default and may require some other way to achieve this would result in this.

```
[INFO] --- cyclonedx:2.7.6-SNAPSHOT:makeBom (default) @ antisamy ---
[WARNING] Unknown keyword additionalItems - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword
```

I'd love to get that other warning to go away too but that is in cyclonedx and doesn't seem it can be hidden.  How might we hid that too?

By default, normal plugin run gets this

```
[INFO] CycloneDX: Resolving Dependencies
[INFO] CycloneDX: Creating BOM version 1.4 with 18 component(s)
[INFO] CycloneDX: Writing and validating BOM (XML): C:\Users\Jeremy\GitHub\antisamy\target\bom.xml
[INFO]            attaching as antisamy-1.7.3-SNAPSHOT-cyclonedx.xml
[INFO] CycloneDX: Writing and validating BOM (JSON): C:\Users\Jeremy\GitHub\antisamy\target\bom.json
[WARNING] Unknown keyword additionalItems - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword
[INFO]            attaching as antisamy-1.7.3-SNAPSHOT-cyclonedx.json
```

Because I reused 'verbose' here as it made sense to do, turning that on would get the following.

```
[INFO] --- cyclonedx:2.7.6-SNAPSHOT:makeBom (default-cli) @ antisamy ---
[INFO] CycloneDX: Parameters
[INFO] ------------------------------------------------------------------------
[INFO] schemaVersion          : 1.4
[INFO] includeBomSerialNumber : true
[INFO] includeCompileScope    : true
[INFO] includeProvidedScope   : true
[INFO] includeRuntimeScope    : true
[INFO] includeTestScope       : false
[INFO] includeSystemScope     : true
[INFO] includeLicenseText     : false
[INFO] outputFormat           : all
[INFO] outputName             : bom
[INFO] ------------------------------------------------------------------------
[INFO] CycloneDX: Resolving Dependencies
[INFO] CycloneDX: Creating BOM version 1.4 with 18 component(s)
[INFO] CycloneDX: Writing and validating BOM (XML): C:\Users\Jeremy\GitHub\antisamy\target\bom.xml
[INFO]            attaching as antisamy-1.7.3-SNAPSHOT-cyclonedx.xml
[INFO] CycloneDX: Writing and validating BOM (JSON): C:\Users\Jeremy\GitHub\antisamy\target\bom.json
[WARNING] Unknown keyword additionalItems - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword
[INFO]            attaching as antisamy-1.7.3-SNAPSHOT-cyclonedx.json
```

I can see using a separate flag but wanted to get feedback first.  Also suggestions on how to squash warning shown above as well as when multi module build and it states it already seen the creation and creates a new one to attach (replaces), how might that be squashed too?

Ideally I would want to run this without any data output at all since no data it outputs IMHO is something I want to see outside of debug run since its value at best is redundant.  Of course it creates those files, that was the point, of course they are in target, again the point.  
