### PR TITLE
feat: expose the outputDirectory configuration parameter as a property

### DIFF
--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -95,7 +95,7 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
      *
      * @since 2.7.5
      */
-    @Parameter(defaultValue = "${project.build.directory}", required = false)
+    @Parameter(property = "outputDirectory", defaultValue = "${project.build.directory}", required = false)
     private File outputDirectory;
 
     /**


### PR DESCRIPTION
Beware: this is a huge PR!

I found it a bit misleading that `outputDirectory` could not be configured by passing the property on command line. This fixes this behavior and makes it consistent with other parameters.