### PR TITLE
support Reproducible SBOM: drop UUID and timestamp when RB mode enabled

### DIFF
--- a/src/it/makeBom/pom.xml
+++ b/src/it/makeBom/pom.xml
@@ -65,6 +65,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <cyclonedx.verbose>false</cyclonedx.verbose><!-- override default plugin value, user still can override with CLI -Dcyclonedx.verbose -->
+        <project.build.outputTimestamp>12345</project.build.outputTimestamp><!-- activate Reproducible Builds mode -->
     </properties>
 
     <dependencies>

--- a/src/it/makeBom/verify.groovy
+++ b/src/it/makeBom/verify.groovy
@@ -9,6 +9,8 @@ assert bomFileXml.text.contains('<reference type="website"><url>https://github.c
 // Reproducible Builds
 assert !bomFileJson.text.contains('"serialNumber"')
 assert !bomFileJson.text.contains('"timestamp"')
+assert bomFileJson.text.contains('"name" : "maven.reproducible",')
+assert bomFileJson.text.contains('"value" : "enabled"')
 
 File bomAggregateFileXml = new File(basedir, "target/bom-makeAggregateBom.xml")
 File bomAggregateFileJson = new File(basedir, "target/bom-makeAggregateBom.json")

--- a/src/it/makeBom/verify.groovy
+++ b/src/it/makeBom/verify.groovy
@@ -6,6 +6,10 @@ assert bomFileJson.exists()
 
 assert bomFileXml.text.contains('<reference type="website"><url>https://github.com/CycloneDX/cyclonedx-maven-plugin</url></reference>')
 
+// Reproducible Builds
+assert !bomFileJson.text.contains('"serialNumber"')
+assert !bomFileJson.text.contains('"timestamp"')
+
 File bomAggregateFileXml = new File(basedir, "target/bom-makeAggregateBom.xml")
 File bomAggregateFileJson = new File(basedir, "target/bom-makeAggregateBom.json")
 

--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -308,6 +308,9 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
                 // activate Reproducible Builds mode
                 includeBomSerialNumber = false;
                 metadata.setTimestamp(null);
+                if (schemaVersion().getVersion() >= 1.3) {
+                    metadata.addProperty(newProperty("maven.reproducible", "enabled"));
+                }
             }
 
             if (schemaVersion().getVersion() >= 1.1 && includeBomSerialNumber) {

--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -195,6 +195,16 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
     @Parameter(property = "cyclonedx.verbose", defaultValue = "false", required = false)
     private boolean verbose = false;
 
+    /**
+     * Timestamp for reproducible output archive entries, either formatted as ISO 8601
+     * <code>yyyy-MM-dd'T'HH:mm:ssXXX</code> or as an int representing seconds since the epoch (like
+     * <a href="https://reproducible-builds.org/docs/source-date-epoch/">SOURCE_DATE_EPOCH</a>).
+     *
+     * @since 2.7.9
+     */
+    @Parameter( defaultValue = "${project.build.outputTimestamp}" )
+    private String outputTimestamp;
+
     @org.apache.maven.plugins.annotations.Component
     private MavenProjectHelper mavenProjectHelper;
 
@@ -293,6 +303,12 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
             getLog().info(String.format(MESSAGE_CREATING_BOM, schemaVersion, components.size()));
             final Bom bom = new Bom();
             bom.setComponents(components);
+
+            if (outputTimestamp != null) {
+                // activate Reproducible Builds mode
+                includeBomSerialNumber = false;
+                metadata.setTimestamp(null);
+            }
 
             if (schemaVersion().getVersion() >= 1.1 && includeBomSerialNumber) {
                 bom.setSerialNumber("urn:uuid:" + UUID.randomUUID());


### PR DESCRIPTION
fixes #226

when Maven Reproducible Builds mode is detected (with `project.build.outputTimestamp`), non-reproducible UUID and timestamp are just removed from SBOM