### PR TITLE
Fix makeAggregateBom failed: Unknown constant pool type 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-dependency-analyzer</artifactId>
-            <version>1.13.1</version>
+            <version>1.13.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
Fix "makeAggregateBom failed: Unknown constant pool type '17'" by updating maven-dependency-analyzer to 1.13.2.

See https://issues.apache.org/jira/browse/MSHARED-1247

For example:

```
Error: 5-05 19:59:54] [autobuild] [ERROR] Failed to execute goal org.cyclonedx:cyclonedx-maven-plugin:2.7.7:makeAggregateBom (make-bom) on project bcel: Execution make-bom of goal org.cyclonedx:cyclonedx-maven-plugin:2.7.7:makeAggregateBom failed: Unknown constant pool type '17' -> [Help 1]
  [2023-05-05 19:59:54] [autobuild] org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.cyclonedx:cyclonedx-maven-plugin:2.7.7:makeAggregateBom (make-bom) on project bcel: Execution make-bom of goal org.cyclonedx:cyclonedx-maven-plugin:2.7.7:makeAggregateBom failed: Unknown constant pool type '17'
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:375)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:351)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:171)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:163)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:299)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:193)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:106)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.cli.MavenCli.execute (MavenCli.java:963)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:296)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.cli.MavenCli.main (MavenCli.java:[199](https://github.com/apache/commons-bcel/actions/runs/4897071853/jobs/8744674014#step:5:200))
  [2023-05-05 19:59:54] [autobuild]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
  [2023-05-05 19:59:54] [autobuild]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
  [2023-05-05 19:59:54] [autobuild]     at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
  [2023-05-05 19:59:54] [autobuild]     at java.lang.reflect.Method.invoke (Method.java:566)
  [2023-05-05 19:59:54] [autobuild]     at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
  [2023-05-05 19:59:54] [autobuild]     at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
  [2023-05-05 19:59:54] [autobuild]     at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
  [2023-05-05 19:59:54] [autobuild]     at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
  [2023-05-05 19:59:54] [autobuild] Caused by: org.apache.maven.plugin.PluginExecutionException: Execution make-bom of goal org.cyclonedx:cyclonedx-maven-plugin:2.7.7:makeAggregateBom failed: Unknown constant pool type '17'
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:148)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:370)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:351)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:171)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:163)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:299)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:193)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:106)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.cli.MavenCli.execute (MavenCli.java:963)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:296)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.cli.MavenCli.main (MavenCli.java:199)
  [2023-05-05 19:59:54] [autobuild]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
  [2023-05-05 19:59:54] [autobuild]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
  [2023-05-05 19:59:54] [autobuild]     at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
  [2023-05-05 19:59:54] [autobuild]     at java.lang.reflect.Method.invoke (Method.java:566)
  [2023-05-05 19:59:54] [autobuild]     at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
  [2023-05-05 19:59:54] [autobuild]     at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
  [2023-05-05 19:59:54] [autobuild]     at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
  [2023-05-05 19:59:54] [autobuild]     at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
  [2023-05-05 19:59:54] [autobuild] Caused by: java.lang.RuntimeException: Unknown constant pool type '17'
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.shared.dependency.analyzer.asm.ConstantPoolParser.parseConstantPoolClassReferences (ConstantPoolParser.java:120)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.shared.dependency.analyzer.asm.ConstantPoolParser.getConstantPoolClassReferences (ConstantPoolParser.java:104)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.shared.dependency.analyzer.asm.DependencyClassFileVisitor.visitClass (DependencyClassFileVisitor.java:59)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.shared.dependency.analyzer.ClassFileVisitorUtils.visitClass (ClassFileVisitorUtils.java:114)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.shared.dependency.analyzer.ClassFileVisitorUtils.visitClass (ClassFileVisitorUtils.java:106)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.shared.dependency.analyzer.ClassFileVisitorUtils.acceptDirectory (ClassFileVisitorUtils.java:97)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.shared.dependency.analyzer.ClassFileVisitorUtils.accept (ClassFileVisitorUtils.java:59)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.shared.dependency.analyzer.asm.ASMDependencyAnalyzer.analyze (ASMDependencyAnalyzer.java:43)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.shared.dependency.analyzer.DefaultProjectDependencyAnalyzer.buildDependencyClasses (DefaultProjectDependencyAnalyzer.java:206)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.shared.dependency.analyzer.DefaultProjectDependencyAnalyzer.buildTestDependencyClasses (DefaultProjectDependencyAnalyzer.java:[200](https://github.com/apache/commons-bcel/actions/runs/4897071853/jobs/8744674014#step:5:201))
  [[202](https://github.com/apache/commons-bcel/actions/runs/4897071853/jobs/8744674014#step:5:203)3-05-05 19:59:54] [autobuild]     at org.apache.maven.shared.dependency.analyzer.DefaultProjectDependencyAnalyzer.analyze (DefaultProjectDependencyAnalyzer.java:68)
  [2023-05-05 19:59:54] [autobuild]     at org.cyclonedx.maven.CycloneDxMojo.doProjectDependencyAnalysis (CycloneDxMojo.java:86)
  [2023-05-05 19:59:54] [autobuild]     at org.cyclonedx.maven.CycloneDxAggregateMojo.extractComponentsAndDependencies (CycloneDxAggregateMojo.java:130)
  [2023-05-05 19:59:54] [autobuild]     at org.cyclonedx.maven.BaseCycloneDxMojo.execute (BaseCycloneDxMojo.java:258)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:370)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:351)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:[215](https://github.com/apache/commons-bcel/actions/runs/4897071853/jobs/8744674014#step:5:216))
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:171)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:163)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:299)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:193)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:106)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.cli.MavenCli.execute (MavenCli.java:963)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:296)
  [2023-05-05 19:59:54] [autobuild]     at org.apache.maven.cli.MavenCli.main (MavenCli.java:199)
  [2023-05-05 19:59:54] [autobuild]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
  [2023-05-05 19:59:54] [autobuild]     at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
  [2023-05-05 19:59:54] [autobuild]     at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
  [2023-05-05 19:59:54] [autobuild]     at java.lang.reflect.Method.invoke (Method.java:566)
  [2023-05-05 19:59:54] [autobuild]     at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
  [2023-05-05 19:59:54] [autobuild]     at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:[225](https://github.com/apache/commons-bcel/actions/runs/4897071853/jobs/8744674014#step:5:226))
  [2023-05-05 19:59:54] [autobuild]     at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
  [2023-05-05 19:59:54] [autobuild]     at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
```
