### PR TITLE
upgrade cyclonedx-maven-plugin to 2.7.9 to produce Reproducible SBOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,7 +283,7 @@
             <plugin>
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
-                <version>2.7.7</version>
+                <version>2.7.9</version>
                 <executions>
                     <execution>
                         <id>cyclonedx-makeBom</id>


### PR DESCRIPTION
use #353 