### PR TITLE
ignore bomGenerator.generate() call

### DIFF
--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -360,7 +360,7 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
             MojoExecutionException {
         if ("all".equalsIgnoreCase(outputFormat) || "xml".equalsIgnoreCase(outputFormat)) {
             final BomXmlGenerator bomGenerator = BomGeneratorFactory.createXml(schemaVersion(), bom);
-            bomGenerator.generate();
+            //bomGenerator.generate();
 
             final String bomString = bomGenerator.toXmlString();
             saveBomToFile(bomString, "xml", new XmlParser());


### PR DESCRIPTION
An error occurred during the execution process: Invalid XML character (Unicode: 0xdccc) found in the element content of the document.

The reason is that there are special characters present in the description of the dependent library, causing the exception. https://github.com/alibaba/transmittable-thread-local/blob/master/pom.xml#L11

![image](https://github.com/CycloneDX/cyclonedx-maven-plugin/assets/232069/8dd689a5-5289-461a-b6c6-402219ed97bb)


