### PR TITLE
switch to m-plugin-report-p introduced in 3.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,11 @@
                     <artifactId>maven-site-plugin</artifactId>
                     <version>3.12.1</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-project-info-reports-plugin</artifactId>
+                    <version>3.4.5</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <resources>
@@ -430,7 +435,7 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-plugin-plugin</artifactId>
+                <artifactId>maven-plugin-report-plugin</artifactId>
                 <version>3.9.0</version>
             </plugin>
         </plugins>


### PR DESCRIPTION
fixes #380

upgrading maven-plugin-plugin to 3.9.0 in 560631f7905614bec0611e7d79f0ee2ca2682b42 broke the report because report goal was extracted to a separate plugin https://issues.apache.org/jira/browse/MPLUGIN-467