### PR TITLE
Extended documentation by pointing out the allowed project types

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ Default Values
 </plugins>
 ```
 
+Project Type
+------------
+In the configuration a `<projectType>` can be set. The default value is `library` but there are more choices:
+
+* application
+* container
+* device
+* file
+* firmware
+* framework
+* library (default)
+* operating-system
+
+Using an unsupported project type will result in applying the default value `library`.
+
 Excluding Projects
 -------------------
 With `makeAggregateBom` goal, it is possible to exclude certain Maven reactor projects (aka modules) from getting included in the aggregate BOM:


### PR DESCRIPTION
Added section to outline the allowed project types and default fallback behaviour.