### PR TITLE
Add support for custom external references

### DIFF
--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -24,6 +24,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginExecution;
 import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
@@ -36,11 +37,7 @@ import org.cyclonedx.exception.GeneratorException;
 import org.cyclonedx.generators.json.BomJsonGenerator;
 import org.cyclonedx.generators.xml.BomXmlGenerator;
 import org.cyclonedx.maven.ProjectDependenciesConverter.BomDependencies;
-import org.cyclonedx.model.Bom;
-import org.cyclonedx.model.Component;
-import org.cyclonedx.model.Dependency;
-import org.cyclonedx.model.Metadata;
-import org.cyclonedx.model.Property;
+import org.cyclonedx.model.*;
 import org.cyclonedx.parsers.JsonParser;
 import org.cyclonedx.parsers.Parser;
 import org.cyclonedx.parsers.XmlParser;
@@ -217,6 +214,22 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
     @Parameter( defaultValue = "${project.build.outputTimestamp}" )
     private String outputTimestamp;
 
+    /**
+     * External references to be added.
+     * <p>
+     * They will be injected in two locations:
+     * </p>
+     * <ol>
+     * <li><code>$.metadata.component.externalReferences[]</code></li>
+     * <li><code>$.components[].externalReferences[]</code> (only for <code>$.components[]</code> provided by the project)</li>
+     * </ol>
+     */
+    @Parameter
+    private ExternalReference[] externalReferences;
+
+    @Parameter(defaultValue = "${mojoExecution}", readonly = true, required = true)
+    private MojoExecution execution;
+
     @org.apache.maven.plugins.annotations.Component
     private MavenProjectHelper mavenProjectHelper;
 
@@ -257,7 +270,7 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
     }
 
     protected Component convert(Artifact artifact) {
-        return modelConverter.convert(artifact, schemaVersion(), includeLicenseText);
+        return modelConverter.convert(execution, artifact, schemaVersion(), includeLicenseText);
     }
 
     /**
@@ -301,7 +314,7 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
 
         String analysis = extractComponentsAndDependencies(topLevelComponents, componentMap, dependencyMap);
         if (analysis != null) {
-            final Metadata metadata = modelConverter.convert(project, projectType, schemaVersion(), includeLicenseText);
+            final Metadata metadata = modelConverter.convert(project, projectType, execution, schemaVersion(), includeLicenseText);
 
             if (schemaVersion().getVersion() >= 1.3) {
                 metadata.addProperty(newProperty("maven.goal", analysis));

--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -220,6 +220,8 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
 
     /**
      * External references to be added to <code>$.metadata.component.externalReferences[]</code>.
+     *
+     * @since 2.7.11
      */
     @Parameter
     private ExternalReference[] externalReferences;

--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -266,7 +266,7 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
     }
 
     protected Component convert(Artifact artifact) {
-        return modelConverter.convert(artifact, schemaVersion(), includeLicenseText, externalReferences);
+        return modelConverter.convert(artifact, schemaVersion(), includeLicenseText);
     }
 
     /**

--- a/src/main/java/org/cyclonedx/maven/DefaultModelConverter.java
+++ b/src/main/java/org/cyclonedx/maven/DefaultModelConverter.java
@@ -18,42 +18,20 @@
  */
 package org.cyclonedx.maven;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Properties;
-import java.util.TreeMap;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import javax.annotation.Nullable;
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.github.packageurl.MalformedPackageURLException;
+import com.github.packageurl.PackageURL;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.MailingList;
-import org.apache.maven.model.Plugin;
 import org.apache.maven.model.building.ModelBuildingRequest;
-import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingException;
 import org.apache.maven.project.ProjectBuildingResult;
 import org.apache.maven.repository.RepositorySystem;
-import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.cyclonedx.CycloneDxSchema;
 import org.cyclonedx.model.Component;
 import org.cyclonedx.model.ExternalReference;
@@ -67,8 +45,18 @@ import org.eclipse.aether.artifact.ArtifactProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.packageurl.MalformedPackageURLException;
-import com.github.packageurl.PackageURL;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 @Singleton
 @Named
@@ -165,7 +153,7 @@ public class DefaultModelConverter implements ModelConverter {
     }
 
     @Override
-    public Component convert(MojoExecution execution, Artifact artifact, CycloneDxSchema.Version schemaVersion, boolean includeLicenseText) {
+    public Component convert(Artifact artifact, CycloneDxSchema.Version schemaVersion, boolean includeLicenseText, ExternalReference[] externalReferences) {
 
         // Populate basic fields from the `Artifact` instance
         final Component component = new Component();
@@ -202,8 +190,7 @@ public class DefaultModelConverter implements ModelConverter {
         if (project != null) {
 
             // Populate external references
-            List<ExternalReference> externalReferences = extractExternalReferences(project, execution);
-            component.setExternalReferences(externalReferences);
+            setExternalReferences(component, externalReferences);
 
             // Extract the rest of the metadata for JARs, i.e., *described* artifacts
             if (isDescribedArtifact(artifact)) {
@@ -217,68 +204,13 @@ public class DefaultModelConverter implements ModelConverter {
 
     }
 
-    private List<ExternalReference> extractExternalReferences(MavenProject project, MojoExecution activeExecution) {
-        Plugin activePlugin = activeExecution.getPlugin();
-        return project
-                .getBuild()
-                .getPlugins()
-                .stream()
-                .filter(plugin -> activePlugin.getGroupId().equals(plugin.getGroupId()) && activePlugin.getArtifactId().equals(plugin.getArtifactId()))
-                .findFirst()
-                .map(plugin -> extractExternalReferences(plugin, activeExecution))
-                .orElseGet(ArrayList::new);
-    }
-
-    private static List<ExternalReference> extractExternalReferences(Plugin plugin, MojoExecution activeExecution) {
-
-        // Collect external references from the execution configuration
-        List<ExternalReference> executionExternalReferences = plugin
-                .getExecutions()
-                .stream()
-                .filter(execution -> activeExecution.getExecutionId().equals(execution.getId()))
-                .flatMap(execution -> {
-                    Xpp3Dom executionConfig = (Xpp3Dom) execution.getConfiguration();
-                    return ExternalReferenceConfigDto.parseDom(executionConfig).stream();
-                })
-                .collect(Collectors.toList());
-
-        // Collect external references from the plugin configuration
-        Xpp3Dom pluginConfig = (Xpp3Dom) plugin.getConfiguration();
-        List<ExternalReference> pluginExternalReferences = ExternalReferenceConfigDto.parseDom(pluginConfig);
-
-        // Combine collected external references
-        return Stream
-                .concat(executionExternalReferences.stream(), pluginExternalReferences.stream())
-                .distinct()
-                .collect(Collectors.toList());
-
-    }
-
-    private static final class ExternalReferenceConfigDto {
-
-        private static final XmlMapper MAPPER = XmlMapper
-                .builder()
-                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-                .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
-                .build();
-
-        private static List<ExternalReference> parseDom(@Nullable Xpp3Dom dom) {
-            if (dom == null) {
-                return new ArrayList<>();
-            }
-            String xml = dom.toString();
-            try {
-                ExternalReferenceConfigDto dto = MAPPER.readValue(xml, ExternalReferenceConfigDto.class);
-                @Nullable List<ExternalReference> externalReferences = dto.externalReferences;
-                return externalReferences != null ? externalReferences : new ArrayList<>();
-            } catch (JsonProcessingException error) {
-                throw new RuntimeException(error);
-            }
+    private static void setExternalReferences(Component component, ExternalReference[] externalReferences) {
+        if (externalReferences == null || externalReferences.length == 0) {
+            return;
         }
-
-        @JsonProperty
-        private List<ExternalReference> externalReferences;
-
+        // We need a mutable `List`, hence `Arrays.asList()` won't work.
+        List<ExternalReference> externalReferences_ = Arrays.stream(externalReferences).collect(Collectors.toList());
+        component.setExternalReferences(externalReferences_);
     }
 
     private boolean isModified(Artifact artifact) {
@@ -433,7 +365,7 @@ public class DefaultModelConverter implements ModelConverter {
     }
 
     @Override
-    public Metadata convert(final MavenProject project, String projectType, MojoExecution execution, CycloneDxSchema.Version schemaVersion, boolean includeLicenseText) {
+    public Metadata convert(final MavenProject project, String projectType, CycloneDxSchema.Version schemaVersion, boolean includeLicenseText, ExternalReference[] externalReferences) {
         final Tool tool = new Tool();
         final Properties properties = readPluginProperties();
         tool.setVendor(properties.getProperty("vendor"));
@@ -459,9 +391,7 @@ public class DefaultModelConverter implements ModelConverter {
         component.setType(resolveProjectType(projectType));
         component.setPurl(generatePackageUrl(project.getArtifact()));
         component.setBomRef(component.getPurl());
-
-        List<ExternalReference> externalReferences = extractExternalReferences(project, execution);
-        component.setExternalReferences(externalReferences);
+        setExternalReferences(component, externalReferences);
         extractComponentMetadata(project, component, schemaVersion, includeLicenseText);
 
         final Metadata metadata = new Metadata();

--- a/src/main/java/org/cyclonedx/maven/ModelConverter.java
+++ b/src/main/java/org/cyclonedx/maven/ModelConverter.java
@@ -19,6 +19,7 @@
 package org.cyclonedx.maven;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 import org.cyclonedx.CycloneDxSchema;
 import org.cyclonedx.model.Component;
@@ -43,21 +44,24 @@ public interface ModelConverter {
      * Converts a Maven artifact (dependency or transitive dependency) into a
      * CycloneDX component.
      *
+     * @param execution the associated execution
      * @param artifact the artifact to convert
      * @param schemaVersion the target CycloneDX schema version
      * @param includeLicenseText should license text be included in bom?
      * @return a CycloneDX component
      */
-    Component convert(Artifact artifact, CycloneDxSchema.Version schemaVersion, boolean includeLicenseText);
+    Component convert(MojoExecution execution, Artifact artifact, CycloneDxSchema.Version schemaVersion, boolean includeLicenseText);
 
     /**
      * Converts a MavenProject into a Metadata object.
      *
      * @param project the MavenProject to convert
      * @param projectType the target CycloneDX component type
+     * @param execution the associated execution
      * @param schemaVersion the target CycloneDX schema version
      * @param includeLicenseText should license text be included in bom?
      * @return a CycloneDX Metadata object
      */
-    Metadata convert(MavenProject project, String projectType, CycloneDxSchema.Version schemaVersion, boolean includeLicenseText);
+    Metadata convert(MavenProject project, String projectType, MojoExecution execution, CycloneDxSchema.Version schemaVersion, boolean includeLicenseText);
+
 }

--- a/src/main/java/org/cyclonedx/maven/ModelConverter.java
+++ b/src/main/java/org/cyclonedx/maven/ModelConverter.java
@@ -47,10 +47,9 @@ public interface ModelConverter {
      * @param artifact the artifact to convert
      * @param schemaVersion the target CycloneDX schema version
      * @param includeLicenseText should license text be included in bom?
-     * @param externalReferences the external references
      * @return a CycloneDX component
      */
-    Component convert(Artifact artifact, CycloneDxSchema.Version schemaVersion, boolean includeLicenseText, ExternalReference[] externalReferences);
+    Component convert(Artifact artifact, CycloneDxSchema.Version schemaVersion, boolean includeLicenseText);
 
     /**
      * Converts a MavenProject into a Metadata object.

--- a/src/main/java/org/cyclonedx/maven/ModelConverter.java
+++ b/src/main/java/org/cyclonedx/maven/ModelConverter.java
@@ -19,10 +19,10 @@
 package org.cyclonedx.maven;
 
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 import org.cyclonedx.CycloneDxSchema;
 import org.cyclonedx.model.Component;
+import org.cyclonedx.model.ExternalReference;
 import org.cyclonedx.model.Metadata;
 
 /**
@@ -44,24 +44,24 @@ public interface ModelConverter {
      * Converts a Maven artifact (dependency or transitive dependency) into a
      * CycloneDX component.
      *
-     * @param execution the associated execution
      * @param artifact the artifact to convert
      * @param schemaVersion the target CycloneDX schema version
      * @param includeLicenseText should license text be included in bom?
+     * @param externalReferences the external references
      * @return a CycloneDX component
      */
-    Component convert(MojoExecution execution, Artifact artifact, CycloneDxSchema.Version schemaVersion, boolean includeLicenseText);
+    Component convert(Artifact artifact, CycloneDxSchema.Version schemaVersion, boolean includeLicenseText, ExternalReference[] externalReferences);
 
     /**
      * Converts a MavenProject into a Metadata object.
      *
      * @param project the MavenProject to convert
      * @param projectType the target CycloneDX component type
-     * @param execution the associated execution
      * @param schemaVersion the target CycloneDX schema version
      * @param includeLicenseText should license text be included in bom?
+     * @param externalReferences the external references
      * @return a CycloneDX Metadata object
      */
-    Metadata convert(MavenProject project, String projectType, MojoExecution execution, CycloneDxSchema.Version schemaVersion, boolean includeLicenseText);
+    Metadata convert(MavenProject project, String projectType, CycloneDxSchema.Version schemaVersion, boolean includeLicenseText, ExternalReference[] externalReferences);
 
 }

--- a/src/test/java/org/cyclonedx/maven/ExternalReferenceTest.java
+++ b/src/test/java/org/cyclonedx/maven/ExternalReferenceTest.java
@@ -45,12 +45,6 @@ public class ExternalReferenceTest extends BaseMavenVerifier {
                 "$.metadata.component.externalReferences[?(@.type=='chat')].url",
                 Collections.singleton("https://acme.com/parent"));
 
-        // Verify parent components
-        assertExternalReferences(
-                new File(projDir, "target/bom.json"),
-                "$.components[?(@.name=='child')].externalReferences[?(@.type=='chat')].url",
-                Arrays.asList("https://acme.com/parent", "https://acme.com/child"));
-
         // Verify child metadata
         assertExternalReferences(
                 new File(projDir, "child/target/bom.json"),

--- a/src/test/java/org/cyclonedx/maven/ExternalReferenceTest.java
+++ b/src/test/java/org/cyclonedx/maven/ExternalReferenceTest.java
@@ -1,0 +1,71 @@
+package org.cyclonedx.maven;
+
+import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
+import io.takari.maven.testing.executor.MavenVersions;
+import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+
+/**
+ * Verifies external references are populated as expected.
+ */
+@RunWith(MavenJUnitTestRunner.class)
+@MavenVersions({"3.6.3"})
+public class ExternalReferenceTest extends BaseMavenVerifier {
+
+    public ExternalReferenceTest(MavenRuntimeBuilder runtimeBuilder) throws Exception {
+        super(runtimeBuilder);
+    }
+
+    @Test
+    public void testAddedExternalReferences() throws Exception {
+
+        // Create the verifier
+        File projDir = resources.getBasedir("external-reference");
+        verifier
+                .forProject(projDir)
+                .withCliOption("-Dcyclonedx-maven-plugin.version=" + getCurrentVersion())
+                .withCliOption("-X")
+                .withCliOption("-B")
+                .execute("clean", "verify")
+                .assertErrorFreeLog();
+
+        // Verify parent metadata
+        assertExternalReferences(
+                new File(projDir, "target/bom.json"),
+                "$.metadata.component.externalReferences[?(@.type=='chat')].url",
+                Collections.singleton("https://acme.com/parent"));
+
+        // Verify parent components
+        assertExternalReferences(
+                new File(projDir, "target/bom.json"),
+                "$.components[?(@.name=='child')].externalReferences[?(@.type=='chat')].url",
+                Arrays.asList("https://acme.com/parent", "https://acme.com/child"));
+
+        // Verify child metadata
+        assertExternalReferences(
+                new File(projDir, "child/target/bom.json"),
+                "$.metadata.component.externalReferences[?(@.type=='chat')].url",
+                Arrays.asList("https://acme.com/parent", "https://acme.com/child"));
+
+    }
+
+    private static void assertExternalReferences(File bomFile, String jsonPath, Iterable<Object> expectedValues) throws IOException {
+        byte[] bomJsonBytes = Files.readAllBytes(bomFile.toPath());
+        String bomJson = new String(bomJsonBytes, StandardCharsets.UTF_8);
+        assertThatJson(bomJson)
+                .inPath(jsonPath)
+                .isArray()
+                .containsOnlyOnceElementsOf(expectedValues);
+    }
+
+}

--- a/src/test/resources/external-reference/child/pom.xml
+++ b/src/test/resources/external-reference/child/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.acme</groupId>
+        <artifactId>parent</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>child</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>${cyclonedx-maven-plugin.version}</version>
+                <configuration>
+                    <externalReferences combine.children="append">
+                        <externalReference>
+                            <type>CHAT</type>
+                            <url>https://acme.com/child</url>
+                        </externalReference>
+                    </externalReferences>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/external-reference/pom.xml
+++ b/src/test/resources/external-reference/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.acme</groupId>
+    <artifactId>parent</artifactId>
+    <packaging>pom</packaging>
+    <version>${revision}</version>
+
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <properties>
+        <revision>1.0.0</revision>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <modules>
+        <module>child</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>${cyclonedx-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-sbom</id>
+                        <goals>
+                            <goal>makeAggregateBom</goal>
+                        </goals>
+                        <phase>verify</phase>
+                        <configuration>
+                            <outputFormat>json</outputFormat>
+                            <externalReferences>
+                                <externalReference>
+                                    <type>CHAT</type>
+                                    <url>https://acme.com/parent</url>
+                                </externalReference>
+                            </externalReferences>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
This PR addresses #421 and adds the configured external references into two different places of the generated SBOM:

1. `$.metadata.component.externalReferences`
1. `$.components[].externalReferences` (only for `$.components` contained by the reactor)

While (1) only requires the basic information about the current Maven module that is being processed, (2) was pretty tricky to get right. For (2), the parent module needs to obtain the external references configured for child modules. Hence, using the value injected into the

```
@Parameter
private ExternalReference[] externalReferences;
```

field of the mojo is of no use there. In `DefaultModelConverter#convert(MojoExecution, Artifact, CycloneDxSchema.Version, boolean)`, I locate the matching plugin and its matching execution, and merge the configuration of the two. Notice the `.distinct()` during this merge – without that, merged external references contain duplicates. My suspicion is `getEffectiveMavenProject()` doesn't always return the _effective_ POM.