### PR TITLE
Add a configuration option to skip undeployed artifacts

### DIFF
--- a/src/it/makeAggregateBom/skipped/deploy-config-force/pom.xml
+++ b/src/it/makeAggregateBom/skipped/deploy-config-force/pom.xml
@@ -23,18 +23,28 @@
 
     <parent>
         <groupId>org.cyclonedx.its</groupId>
-        <artifactId>makeAggregateBom</artifactId>
+        <artifactId>skipped</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>
-    <artifactId>skipped</artifactId>
-    <packaging>pom</packaging>
+    <artifactId>deploy-config-force</artifactId>
 
-    <modules>
-      <module>deploy-property</module>
-      <module>deploy-property-force</module>
-      <module>deploy-config</module>
-      <module>deploy-config-force</module>
-      <module>nexus-property</module>
-      <module>nexus-config</module>
-    </modules>
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.cyclonedx</groupId>
+          <artifactId>cyclonedx-maven-plugin</artifactId>
+          <configuration>
+            <skipNotDeployed>false</skipNotDeployed>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>3.1.1</version>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
+        </plugin>
+      </plugins>
+    </build>
 </project>

--- a/src/it/makeAggregateBom/skipped/deploy-property-force/pom.xml
+++ b/src/it/makeAggregateBom/skipped/deploy-property-force/pom.xml
@@ -23,18 +23,13 @@
 
     <parent>
         <groupId>org.cyclonedx.its</groupId>
-        <artifactId>makeAggregateBom</artifactId>
+        <artifactId>skipped</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>
-    <artifactId>skipped</artifactId>
-    <packaging>pom</packaging>
+    <artifactId>deploy-property-force</artifactId>
 
-    <modules>
-      <module>deploy-property</module>
-      <module>deploy-property-force</module>
-      <module>deploy-config</module>
-      <module>deploy-config-force</module>
-      <module>nexus-property</module>
-      <module>nexus-config</module>
-    </modules>
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <cyclonedx.skipNotDeployed>false</cyclonedx.skipNotDeployed>
+    </properties>
 </project>

--- a/src/it/makeAggregateBom/verify.groovy
+++ b/src/it/makeAggregateBom/verify.groovy
@@ -30,6 +30,8 @@ assertBomFiles("impls/target/bom", false)
 assertBomFiles("impls/impl-A/target/bom", false)
 assertBomFiles("impls/impl-B/target/bom", false)
 assertBomFiles("skipped/target/bom", false)
+assertBomFiles("skipped/deploy-config-force/target/bom", false)
+assertBomFiles("skipped/deploy-property-force/target/bom", false)
 
 assertNoBomFiles("skipped/deploy-config/target/bom")
 assertNoBomFiles("skipped/deploy-property/target/bom")
@@ -38,16 +40,16 @@ assertNoBomFiles("skipped/nexus-property/target/bom")
 
 var buildLog = new File(basedir, "build.log").text
 
-assert 13 == (buildLog =~ /\[INFO\] CycloneDX: Resolving Dependencies/).size()
+assert 17 == (buildLog =~ /\[INFO\] CycloneDX: Resolving Dependencies/).size()
 assert 2 == (buildLog =~ /\[INFO\] CycloneDX: Resolving Aggregated Dependencies/).size()
 
-// 15 = 7 modules for main cyclonedx-makeAggregateBom execution
+// 19 = 9 modules for main cyclonedx-makeAggregateBom execution
 //    + 1 for root module cyclonedx-makeAggregateBom-root-only execution
-//    + 7 modules for additional cyclonedx-makeBom execution
-assert 15 == (buildLog =~ /\[INFO\] CycloneDX: Writing and validating BOM \(XML\)/).size()
-assert 15 == (buildLog =~ /\[INFO\] CycloneDX: Writing and validating BOM \(JSON\)/).size()
-// cyclonedx-makeAggregateBom-root-only execution skips 5 non-root modules
-assert 6 == (buildLog =~ /\[INFO\] Skipping CycloneDX on non-execution root/).size()
+//    + 9 modules for additional cyclonedx-makeBom execution
+assert 19 == (buildLog =~ /\[INFO\] CycloneDX: Writing and validating BOM \(XML\)/).size()
+assert 19 == (buildLog =~ /\[INFO\] CycloneDX: Writing and validating BOM \(JSON\)/).size()
+// cyclonedx-makeAggregateBom-root-only execution skips 7 non-root modules
+assert 8 == (buildLog =~ /\[INFO\] Skipping CycloneDX on non-execution root/).size()
 
 // [WARNING] artifact org.cyclonedx.its:api:xml:cyclonedx:1.0-SNAPSHOT already attached, replace previous instance
 assert 0 == (buildLog =~ /-SNAPSHOT already attached, replace previous instance/).size()
@@ -72,6 +74,8 @@ assertBomEqualsNonAggregate("util/target/bom")
 assertBomEqualsNonAggregate("impls/target/bom")
 assertBomEqualsNonAggregate("impls/impl-A/target/bom")
 assertBomEqualsNonAggregate("impls/impl-B/target/bom")
+assertBomEqualsNonAggregate("skipped/deploy-config-force/target/bom")
+assertBomEqualsNonAggregate("skipped/deploy-property-force/target/bom")
 
 // dependencies for root component in makeAggregateBom is the list of modules
 String bom = new File(basedir, 'target/bom.xml').text

--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -278,9 +278,18 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
         return Boolean.parseBoolean(System.getProperty("cyclonedx.skip", Boolean.toString(skip)));
     }
 
+    protected String getSkipReason() {
+        return null;
+    }
+
     public void execute() throws MojoExecutionException {
         if (shouldSkip()) {
-            getLog().info("Skipping CycloneDX");
+            final String skipReason = getSkipReason();
+            if (skipReason != null) {
+                getLog().info("Skipping CycloneDX goal, because " + skipReason);
+            } else {
+                getLog().info("Skipping CycloneDX goal");
+            }
             return;
         }
         logParameters();
@@ -475,7 +484,7 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
      *
      * @return Component.Scope - REQUIRED, OPTIONAL or null if it cannot be determined
      *
-     * @see detectUnusedForOptionalScope
+     * @see #detectUnusedForOptionalScope
      */
     private Component.Scope getComponentScope(Artifact artifact, ProjectDependencyAnalysis projectDependencyAnalysis) {
         if (detectUnusedForOptionalScope) {

--- a/src/main/java/org/cyclonedx/maven/CycloneDxAggregateMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxAggregateMojo.java
@@ -91,7 +91,7 @@ public class CycloneDxAggregateMojo extends CycloneDxMojo {
         if (excludeTestProject && mavenProject.getArtifactId().contains("test")) {
             shouldExclude = true;
         }
-        if (!BaseCycloneDxMojo.isDeployable(mavenProject)) {
+        if (skipNotDeployed && !BaseCycloneDxMojo.isDeployable(mavenProject)) {
             shouldExclude = true;
         }
         return shouldExclude;

--- a/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
@@ -48,6 +48,14 @@ import java.util.Set;
 public class CycloneDxMojo extends BaseCycloneDxMojo {
 
     /**
+     * Only runs this goal if the module does not skip deploy.
+     *
+     * @since 2.8.0
+     */
+    @Parameter(property = "cyclonedx.skipNotDeployed", defaultValue = "true", required = false)
+    protected boolean skipNotDeployed = true;
+
+    /**
      * Specify the Maven project dependency analyzer to use (plexus component role-hint). By default,
      * <a href="https://maven.apache.org/shared/maven-dependency-analyzer/">maven-dependency-analyzer</a>'s one
      * is used.
@@ -97,7 +105,15 @@ public class CycloneDxMojo extends BaseCycloneDxMojo {
     @Override
     protected boolean shouldSkip() {
         // The list of artifacts would be empty
-        return super.shouldSkip() || !isDeployable(getProject());
+        return super.shouldSkip() || skipNotDeployed && !isDeployable(getProject());
+    }
+
+    @Override
+    protected String getSkipReason() {
+        if (super.shouldSkip()) {
+            return super.getSkipReason();
+        }
+        return "module skips deploy";
     }
 
     protected String extractComponentsAndDependencies(final Set<String> topLevelComponents, final Map<String, Component> components, final Map<String, Dependency> dependencies) throws MojoExecutionException {


### PR DESCRIPTION
This adds a `<skipNotDeployed>` plugin configuration option. If set to `false`, even artifacts that do not have a deploy execution are used to generate the SBOM.

Closes #430