### PR TITLE
use metadata properties in UUID

### DIFF
--- a/src/it/makeBom/verify.groovy
+++ b/src/it/makeBom/verify.groovy
@@ -9,7 +9,6 @@ assert bomFileXml.text.contains('<reference type="website"><url>https://github.c
 assert !bomFileXml.text.contains('<property name="maven.optional.unused">')
 
 // Reproducible Builds
-assert !bomFileJson.text.contains('"serialNumber"')
 assert !bomFileJson.text.contains('"timestamp"')
 assert bomFileJson.text.contains('"name" : "cdx:reproducible",')
 assert bomFileJson.text.contains('"value" : "enabled"')

--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -341,7 +341,7 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
             }
 
             if (schemaVersion().getVersion() >= 1.1 && includeBomSerialNumber) {
-                String serialNumber = generateSerialNumber();
+                String serialNumber = generateSerialNumber(metadata.getProperties());
                 bom.setSerialNumber(serialNumber);
             }
 
@@ -371,9 +371,18 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
         }
     }
 
-    private String generateSerialNumber() {
-        String seed = String.format("%s:%s:%s", project.getGroupId(), project.getArtifactId(), project.getVersion());
-        UUID uuid = UUID.nameUUIDFromBytes(seed.getBytes(StandardCharsets.UTF_8));
+    private String generateSerialNumber(List<Property> properties) {
+        String gav = String.format("%s:%s:%s", project.getGroupId(), project.getArtifactId(), project.getVersion());
+        StringBuilder sb = new StringBuilder(gav);
+        if (properties != null) {
+            for(Property prop: properties) {
+                sb.append(';');
+                sb.append(prop.getName());
+                sb.append('=');
+                sb.append(prop.getValue());
+            }
+        }
+        UUID uuid = UUID.nameUUIDFromBytes(sb.toString().getBytes(StandardCharsets.UTF_8));
         return String.format("urn:uuid:%s", uuid);
     }
 

--- a/src/test/java/org/cyclonedx/maven/Issue420Test.java
+++ b/src/test/java/org/cyclonedx/maven/Issue420Test.java
@@ -22,15 +22,13 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 @MavenVersions({"3.6.3"})
 public class Issue420Test extends BaseMavenVerifier {
 
-    private static final String SERIAL_NUMBER = "urn:uuid:f1a73cb3-dab9-3592-a2a9-825cf9eab862";
-
     public Issue420Test(MavenRuntimeBuilder runtimeBuilder) throws Exception {
         super(runtimeBuilder);
     }
 
     @Test
     public void testDefaults() throws Exception {
-        test(new String[0], SERIAL_NUMBER);
+        test(new String[0], "urn:uuid:af111a48-2091-3e2e-ad2e-60b1975b651d");
     }
 
     @Test
@@ -40,7 +38,7 @@ public class Issue420Test extends BaseMavenVerifier {
 
     @Test
     public void testWhenOutputTimestampIsSet() throws Exception {
-        test(new String[]{"-Dproject.build.outputTimestamp=2023-11-08T00:00:00Z"}, SERIAL_NUMBER);
+        test(new String[]{"-Dproject.build.outputTimestamp=2023-11-08T00:00:00Z"}, "urn:uuid:3e383c4c-ef61-3eba-8214-3ecd46c4bbee");
     }
 
     @Test


### PR DESCRIPTION
if multiple SBOMs are generated for a module with different configurations, each one needs a different UUID:
given metatada properties are exactly done to show plugin configuration, we just need to use them as a source for UUID in #420 