### PR TITLE
Update CycloneDX Description Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ CycloneDX Maven Plugin
 =========
 
 The CycloneDX Maven plugin generates CycloneDX Software Bill of Materials (SBOM) containing the aggregate of all direct 
-and transitive dependencies of a project. CycloneDX is a lightweight software bill of materials 
-(SBOM) standard designed for use in application security contexts and supply chain component analysis.
+and transitive dependencies of a project. CycloneDX is a full-stack SBOM standard designed for use in application security
+contexts and supply chain component analysis.
 
 Maven Usage
 -------------------


### PR DESCRIPTION
CycloneDX should be described as full-stack in order to be consistent with description on CycloneDX website, etc.

Simplified text to remove repetition of explanation that SBOM means "Software Bill of Materials".

Signed-off-by: Mark Symons <mark.symons@fujitsu.com>