### PR TITLE
check if configured schemaVersion is supported

### DIFF
--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -82,6 +82,7 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
      */
     @Parameter(property = "schemaVersion", defaultValue = "1.5", required = false)
     private String schemaVersion;
+    private CycloneDxSchema.Version effectiveSchemaVersion = null;
 
     /**
      * The CycloneDX output format that should be generated (<code>xml</code>, <code>json</code> or <code>all</code>).
@@ -311,6 +312,10 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
             }
             return;
         }
+        if (!schemaVersion().getVersionString().equals(schemaVersion)) {
+            getLog().warn("Invalid schemaVersion configured '" + schemaVersion +"', using " + effectiveSchemaVersion.getVersionString());
+            schemaVersion = effectiveSchemaVersion.getVersionString();
+        }
         logParameters();
 
         // top level components do not currently set their scope, we track these to prevent merging of scopes
@@ -465,19 +470,22 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
      * @return the CycloneDX schema to use
      */
     protected CycloneDxSchema.Version schemaVersion() {
-        if ("1.0".equals(schemaVersion)) {
-            return CycloneDxSchema.Version.VERSION_10;
-        } else if ("1.1".equals(schemaVersion)) {
-            return CycloneDxSchema.Version.VERSION_11;
-        } else if ("1.2".equals(schemaVersion)) {
-            return CycloneDxSchema.Version.VERSION_12;
-        } else if ("1.3".equals(schemaVersion)) {
-            return CycloneDxSchema.Version.VERSION_13;
-        } else if ("1.4".equals(schemaVersion)) {
-            return CycloneDxSchema.Version.VERSION_14;
-        } else {
-            return CycloneDxSchema.Version.VERSION_15;
+        if (effectiveSchemaVersion == null) {
+            if ("1.0".equals(schemaVersion)) {
+                effectiveSchemaVersion = CycloneDxSchema.Version.VERSION_10;
+            } else if ("1.1".equals(schemaVersion)) {
+                effectiveSchemaVersion = CycloneDxSchema.Version.VERSION_11;
+            } else if ("1.2".equals(schemaVersion)) {
+                effectiveSchemaVersion = CycloneDxSchema.Version.VERSION_12;
+            } else if ("1.3".equals(schemaVersion)) {
+                effectiveSchemaVersion = CycloneDxSchema.Version.VERSION_13;
+            } else if ("1.4".equals(schemaVersion)) {
+                effectiveSchemaVersion = CycloneDxSchema.Version.VERSION_14;
+            } else {
+                effectiveSchemaVersion = CycloneDxSchema.Version.VERSION_15;
+            }
         }
+        return effectiveSchemaVersion;
     }
 
     protected void logAdditionalParameters() {

--- a/src/test/java/org/cyclonedx/maven/VerboseTest.java
+++ b/src/test/java/org/cyclonedx/maven/VerboseTest.java
@@ -2,6 +2,7 @@ package org.cyclonedx.maven;
 
 import java.io.File;
 
+import org.cyclonedx.CycloneDxSchema;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -46,5 +47,20 @@ public class VerboseTest extends BaseMavenVerifier {
                 .execute("verify")
                 .assertErrorFreeLog()
                 .assertLogText("[INFO] CycloneDX: Parameters"); // check goal verbose output
+    }
+
+    @Test
+    public void testUnsupportedSchemaVersionCli() throws Exception {
+        File projDir = resources.getBasedir("verbose");
+
+        verifier
+                .forProject(projDir)
+                .withCliOption("-Dcurrent.version=" + getCurrentVersion()) // inject cyclonedx-maven-plugin version
+                .withCliOption("-B")
+                .withCliOption("-DschemaVersion=1.5.1")
+                .execute("verify")
+                .assertErrorFreeLog()
+                .assertLogText("[WARNING] Invalid schemaVersion configured '1.5.1', using " + CycloneDxSchema.VERSION_LATEST.getVersionString()) // check warning on invalid schema version
+                .assertLogText("[INFO] CycloneDX: Creating BOM version " + CycloneDxSchema.VERSION_LATEST.getVersionString() + " with 0 component(s)"); // and display effective schema version
     }
 }


### PR DESCRIPTION
fixes #469

in case of unsupported schemaVersion, warns and uses latest supported:

```
[INFO] --- cyclonedx-maven-plugin:2.8.0-SNAPSHOT:makeBom (default) @ issue-280 ---
[WARNING] Invalid schemaVersion configured '1.5.1', using 1.5
[INFO] CycloneDX: Resolving Dependencies
[INFO] CycloneDX: Creating BOM version 1.5 with 0 component(s)
```