### PR TITLE
convert external reference type by value instead of CONSTANT_NAME

### DIFF
--- a/src/main/java/org/cyclonedx/maven/CycloneDxAggregateMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxAggregateMojo.java
@@ -42,7 +42,8 @@ import java.util.Set;
         defaultPhase = LifecyclePhase.PACKAGE,
         threadSafe = true,
         aggregator = true,
-        requiresOnline = true
+        requiresOnline = true,
+        configurator = "cyclonedx-mojo-component-configurator"
 )
 public class CycloneDxAggregateMojo extends CycloneDxMojo {
     @Parameter(property = "reactorProjects", readonly = true, required = true)

--- a/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
@@ -43,7 +43,8 @@ import java.util.Set;
         name = "makeBom",
         defaultPhase = LifecyclePhase.PACKAGE,
         threadSafe = true,
-        requiresOnline = true
+        requiresOnline = true,
+        configurator = "cyclonedx-mojo-component-configurator"
 )
 public class CycloneDxMojo extends BaseCycloneDxMojo {
 

--- a/src/main/java/org/cyclonedx/maven/CycloneDxPackageMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxPackageMojo.java
@@ -42,7 +42,8 @@ import java.util.Set;
         defaultPhase = LifecyclePhase.PACKAGE,
         threadSafe = true,
         aggregator = true,
-        requiresOnline = true
+        requiresOnline = true,
+        configurator = "cyclonedx-mojo-component-configurator"
 )
 public class CycloneDxPackageMojo extends BaseCycloneDxMojo {
     @Parameter(property = "reactorProjects", readonly = true, required = true)

--- a/src/main/java/org/cyclonedx/maven/ExtendedMojoConfigurator.java
+++ b/src/main/java/org/cyclonedx/maven/ExtendedMojoConfigurator.java
@@ -1,0 +1,16 @@
+package org.cyclonedx.maven;
+
+import org.codehaus.plexus.component.configurator.BasicComponentConfigurator;
+import org.codehaus.plexus.personality.plexus.lifecycle.phase.Initializable;
+import org.codehaus.plexus.personality.plexus.lifecycle.phase.InitializationException;
+
+import javax.inject.Named;
+
+@Named("cyclonedx-mojo-component-configurator")
+public class ExtendedMojoConfigurator extends BasicComponentConfigurator implements Initializable {
+
+    @Override
+    public void initialize() throws InitializationException {
+        converterLookup.registerConverter(new ExternalReferenceTypeConverter());
+    }
+}

--- a/src/main/java/org/cyclonedx/maven/ExternalReferenceTypeConverter.java
+++ b/src/main/java/org/cyclonedx/maven/ExternalReferenceTypeConverter.java
@@ -1,0 +1,28 @@
+package org.cyclonedx.maven;
+
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.converters.basic.AbstractBasicConverter;
+
+import org.cyclonedx.model.ExternalReference;
+
+/**
+ * Custom Plexus BasicConverter to instantiate <code>ExternalReference.Type</code> from a String.
+ *
+ * @see ExternalReference.Type
+ */
+public class ExternalReferenceTypeConverter extends AbstractBasicConverter {
+
+    @Override
+    public boolean canConvert(Class type) {
+        return ExternalReference.Type.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public Object fromString(String string) throws ComponentConfigurationException {
+        Object value = ExternalReference.Type.fromString(string);
+        if (value == null) {
+            throw new ComponentConfigurationException("Unsupported ExternalReference type: " + string);
+        }
+        return value;
+    }
+}

--- a/src/site/markdown/external-references.md
+++ b/src/site/markdown/external-references.md
@@ -38,7 +38,7 @@ You can add more external references the component that the BOM describes by plu
   <configuration>
     <externalReferences>
       <externalReference>
-        <type>EXTERNAL_REFERENCE_TYPE</type><-- for "external-reference-type"-->
+        <type>... external-reference-type ...</type>
         <url>... value ...</url>
         <comment>(optional) comment</comment>
       </externalReference>
@@ -47,11 +47,9 @@ You can add more external references the component that the BOM describes by plu
 </plugin>
 ```
 
-Notice that the type value in the plugin configuration refers to a [CycloneDX Core (Java) library constant name][external-reference-type-constants]
-corresponding to [CycloneDX type][external-reference-type].
+See valid [CycloneDX external reference types][external-reference-type].
 
 [maven-model]: https://maven.apache.org/ref/current/maven-model/maven.html
 [metadata-component]: https://cyclonedx.org/docs/1.5/json/#metadata_component
 [components]: https://cyclonedx.org/docs/1.5/json/#components
 [external-reference-type]: https://cyclonedx.org/docs/1.5/json/#metadata_component_externalReferences_items_type
-[external-reference-type-constants]: https://cyclonedx.github.io/cyclonedx-core-java/org/cyclonedx/model/ExternalReference.Type.html

--- a/src/test/resources/external-reference/child/pom.xml
+++ b/src/test/resources/external-reference/child/pom.xml
@@ -31,7 +31,7 @@
                     <schemaVersion>1.4</schemaVersion>
                     <externalReferences combine.children="append">
                         <externalReference>
-                            <type>CHAT</type>
+                            <type>chat</type>
                             <url>https://acme.com/child</url>
                         </externalReference>
                     </externalReferences>

--- a/src/test/resources/external-reference/pom.xml
+++ b/src/test/resources/external-reference/pom.xml
@@ -90,12 +90,12 @@
                             <outputFormat>json</outputFormat>
                             <externalReferences><!-- additional configured external references -->
                                 <externalReference>
-                                    <type>CHAT</type><!-- Java ExternalReference.Type constant for "chat" CycloneDX external reference type -->
+                                    <type>chat</type>
                                     <url>https://acme.com/parent</url>
                                     <comment>optional comment</comment>
                                 </externalReference>
                                 <externalReference>
-                                    <type>RELEASE_NOTES</type><!-- Java ExternalReference.Type constant for "release-notes" CycloneDX external reference type -->
+                                    <type>release-notes</type>
                                     <url>https://github.com/CycloneDX/cyclonedx-maven-plugin/releases</url>
                                 </externalReference>
                             </externalReferences>


### PR DESCRIPTION
it's much easier to understand configuration with external reference type value like
```
<type>release-notes</type>
```

than previously default constant value
```
<type>RELEASE_NOTES</type>
```

fixes #463