### PR TITLE
Set component evidence for 1.5 spec

### DIFF
--- a/src/main/java/org/cyclonedx/maven/DefaultModelConverter.java
+++ b/src/main/java/org/cyclonedx/maven/DefaultModelConverter.java
@@ -218,6 +218,7 @@ public class DefaultModelConverter implements ModelConverter {
             final String jarPath = artifact.getFile().getAbsolutePath();
             final String sha1Path = jarPath.replace(".jar", ".jar.sha1");
             if (jarPath.contains(".m2")) {
+                // This removes the home directory which might be sensitive
                 fileMethod.setValue(Paths.get(".m2", jarPath.split(".m2")[1]).toString());
             } else {
                 fileMethod.setValue(jarPath);


### PR DESCRIPTION
Example bom with evidence.identity for java-sec-code.

[bom.json.txt](https://github.com/CycloneDX/cyclonedx-maven-plugin/files/15182108/bom.json.txt)
[bom.xml.txt](https://github.com/CycloneDX/cyclonedx-maven-plugin/files/15182109/bom.xml.txt)

Also includes few tweaks to use `isEmpty` method.

Currently, only sha1 files under the maven cache are used for comparison. Perhaps this could be made generic in the future to support all supported hashes.
