### PR TITLE
Track repository_url

### DIFF
--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -524,11 +524,11 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
             final Component component = components.get(purl);
             final ArtifactRepository repository = artifactRemoteRepositories.get(purl);
             String repository_url = "";
-            // We are only interested in non-central repository urls
-            if (repository instanceof RemoteRepository && !repository.getId().equals("central")) {
+            if (repository instanceof RemoteRepository) {
                 try {
                     String url = ((RemoteRepository) repository).getUrl();
-                    if (url != null) {
+                    // As per purl spec, only repo.maven.apache.org/maven2 is considered the default
+                    if (url != null && !url.startsWith("https://repo.maven.apache.org/maven2")) {
                         repository_url = "&repository_url=" + URLEncoder.encode(url, "UTF-8");
                     }
                 } catch (UnsupportedEncodingException e) {
@@ -543,8 +543,9 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
                 }
                 components.put(purl, newComponent);
             } else if (!topLevelComponents.contains(purl)) {
-                if (!repository_url.isEmpty()) {
-                    component.setPurl(component.getPurl() + repository_url);
+                String currentPurl = component.getPurl();
+                if (!repository_url.isEmpty() && !currentPurl.contains("repository_url")) {
+                    component.setPurl(currentPurl + repository_url);
                 }
                 component.setScope(mergeScopes(component.getScope(), artifactScope));
             }

--- a/src/main/java/org/cyclonedx/maven/CycloneDxAggregateMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxAggregateMojo.java
@@ -130,7 +130,7 @@ public class CycloneDxAggregateMojo extends CycloneDxMojo {
             components.put(projectBomComponent.getPurl(), projectBomComponent);
             topLevelComponents.add(projectBomComponent.getPurl());
 
-            populateComponents(topLevelComponents, components, bomDependencies.getArtifacts(), doProjectDependencyAnalysis(mavenProject, bomDependencies));
+            populateComponents(topLevelComponents, components, bomDependencies.getArtifacts(), bomDependencies.getArtifactRemoteRepositories(), doProjectDependencyAnalysis(mavenProject, bomDependencies));
 
             projectDependencies.forEach(dependencies::putIfAbsent);
         }

--- a/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
@@ -127,7 +127,7 @@ public class CycloneDxMojo extends BaseCycloneDxMojo {
         components.put(projectBomComponent.getPurl(), projectBomComponent);
         topLevelComponents.add(projectBomComponent.getPurl());
 
-        populateComponents(topLevelComponents, components, bomDependencies.getArtifacts(), doProjectDependencyAnalysis(getProject(), bomDependencies));
+        populateComponents(topLevelComponents, components, bomDependencies.getArtifacts(), bomDependencies.getArtifactRemoteRepositories(), doProjectDependencyAnalysis(getProject(), bomDependencies));
 
         projectDependencies.forEach(dependencies::putIfAbsent);
 

--- a/src/main/java/org/cyclonedx/maven/CycloneDxPackageMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxPackageMojo.java
@@ -70,7 +70,7 @@ public class CycloneDxPackageMojo extends BaseCycloneDxMojo {
             components.put(projectBomComponent.getPurl(), projectBomComponent);
             topLevelComponents.add(projectBomComponent.getPurl());
 
-            populateComponents(topLevelComponents, components, bomDependencies.getArtifacts(), null);
+            populateComponents(topLevelComponents, components, bomDependencies.getArtifacts(), bomDependencies.getArtifactRemoteRepositories(), null);
 
             projectDependencies.forEach(dependencies::putIfAbsent);
         }

--- a/src/main/java/org/cyclonedx/maven/DefaultModelConverter.java
+++ b/src/main/java/org/cyclonedx/maven/DefaultModelConverter.java
@@ -218,6 +218,7 @@ public class DefaultModelConverter implements ModelConverter {
             final String jarPath = artifact.getFile().getAbsolutePath();
             final String sha1Path = jarPath.replace(".jar", ".jar.sha1");
             if (jarPath.contains(".m2")) {
+                // This removes the home directory which might be sensitive
                 fileMethod.setValue(Paths.get(".m2", jarPath.split(".m2")[1]).toString());
             } else {
                 fileMethod.setValue(jarPath);

--- a/src/main/java/org/cyclonedx/maven/ProjectDependenciesConverter.java
+++ b/src/main/java/org/cyclonedx/maven/ProjectDependenciesConverter.java
@@ -24,6 +24,7 @@ import org.apache.maven.project.MavenProject;
 import org.cyclonedx.model.Component;
 import org.cyclonedx.model.Dependency;
 import org.cyclonedx.model.Metadata;
+import org.eclipse.aether.repository.ArtifactRepository;
 
 import java.util.Map;
 
@@ -66,10 +67,13 @@ public interface ProjectDependenciesConverter {
         private final Map<String, Artifact> artifacts;
         private final Map<String, Artifact> dependencyArtifacts;
 
-        public BomDependencies(final Map<String, Dependency> dependencies, final Map<String, Artifact> artifacts, final Map<String, Artifact> dependencyArtifacts) {
+        private final Map<String, ArtifactRepository> artifactRemoteRepositories;
+
+        public BomDependencies(final Map<String, Dependency> dependencies, final Map<String, Artifact> artifacts, final Map<String, Artifact> dependencyArtifacts, final Map<String, ArtifactRepository> artifactRemoteRepositories) {
             this.dependencies = dependencies;
             this.artifacts = artifacts;
             this.dependencyArtifacts = dependencyArtifacts;
+            this.artifactRemoteRepositories = artifactRemoteRepositories;
         }
 
         public final Map<String, Dependency> getDependencies() {
@@ -83,5 +87,7 @@ public interface ProjectDependenciesConverter {
         public final Map<String, Artifact> getArtifacts() {
             return artifacts;
         }
+
+        public final Map<String, ArtifactRepository> getArtifactRemoteRepositories() { return artifactRemoteRepositories; }
     }
 }


### PR DESCRIPTION
Supersedes #494 

With this PR, purl for the components would include `repository_url` qualifier for repositories that is not `https://repo.maven.apache.org/maven2` as per purl [spec](https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#maven).

Example BOM generated for the repo https://github.com/eclipse-jkube/jkube is attached.

[bom.xml.txt](https://github.com/CycloneDX/cyclonedx-maven-plugin/files/15194937/bom.xml.txt)
[bom.json.txt](https://github.com/CycloneDX/cyclonedx-maven-plugin/files/15194938/bom.json.txt)
