### PR TITLE
replace CDX 1.5 deprecated tool

### DIFF
--- a/src/test/java/org/cyclonedx/maven/Issue314OptionalTest.java
+++ b/src/test/java/org/cyclonedx/maven/Issue314OptionalTest.java
@@ -16,7 +16,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
 
 import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
 import io.takari.maven.testing.executor.MavenVersions;
@@ -52,9 +51,8 @@ public class Issue314OptionalTest extends BaseMavenVerifier {
 
       final Document bom = readXML(new File(projDir, "dependency_A/target/bom.xml"));
 
-      final NodeList componentsList = bom.getElementsByTagName("components");
-      assertEquals("Expected a single components element", 1, componentsList.getLength());
-      final Element components = (Element)componentsList.item(0);
+      final Element components = getElement(getElement(bom, "bom"), "components");
+      assertNotNull("bom is missing components", components);
 
       final Element componentBNode = getComponentNode(components, ISSUE_314_DEPENDENCY_B);
       final Element componentBScope = getElement(componentBNode, "scope");
@@ -92,9 +90,8 @@ public class Issue314OptionalTest extends BaseMavenVerifier {
 
       final Document bom = readXML(new File(projDir, "dependency_A/target/bom.xml"));
 
-      final NodeList componentsList = bom.getElementsByTagName("components");
-      assertEquals("Expected a single components element", 1, componentsList.getLength());
-      final Element components = (Element)componentsList.item(0);
+      final Element components = getElement(getElement(bom, "bom"), "components");
+      assertNotNull("bom is missing components", components);
 
       final Element componentBNode = getComponentNode(components, ISSUE_314_DEPENDENCY_B);
       final Element componentBScope = getElement(componentBNode, "scope");

--- a/src/test/java/org/cyclonedx/maven/TestUtils.java
+++ b/src/test/java/org/cyclonedx/maven/TestUtils.java
@@ -16,7 +16,7 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 class TestUtils {
-    static Element getElement(final Element parent, final String elementName) throws Exception {
+    static Element getElement(final Node parent, final String elementName) throws Exception {
         Element element = null;
         Node child = parent.getFirstChild();
         while (child != null) {


### PR DESCRIPTION
fixes #487

for CDX 1.5+, generate:

```xml
<bom xmlns="http://cyclonedx.org/schema/bom/1.5">
  <metadata>
    <tools>
      <components>
        <component type="library">
          <author>OWASP Foundation</author>
          <group>org.cyclonedx</group>
          <name>cyclonedx-maven-plugin</name>
          <version>2.8.1-SNAPSHOT</version>
          <description>CycloneDX Maven plugin</description>
          <hashes>
...
          </hashes>
        </component>
      </components>
    </tools>
...
```

instead of
```xml
<bom xmlns="http://cyclonedx.org/schema/bom/1.4">
  <metadata>
    <tools>
      <tool>
        <vendor>OWASP Foundation</vendor>
        <name>CycloneDX Maven plugin</name>
        <version>2.8.1-SNAPSHOT</version>
        <hashes>
...
        </hashes>
      </tool>
    </tools>
...
```