### PR TITLE
Make log output more easy to understand by sorting

### DIFF
--- a/src/main/java/org/cyclonedx/maven/CycloneDxAggregateMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxAggregateMojo.java
@@ -27,6 +27,7 @@ import org.cyclonedx.maven.ProjectDependenciesConverter.BomDependencies;
 import org.cyclonedx.model.Component;
 import org.cyclonedx.model.Dependency;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -117,9 +118,10 @@ public class CycloneDxAggregateMojo extends CycloneDxMojo {
         // root project: analyze and aggregate all the modules
         getLog().info((reactorProjects.size() <= 1) ? MESSAGE_RESOLVING_DEPS : MESSAGE_RESOLVING_AGGREGATED_DEPS);
 
+        final List<String> excludedProjects = new ArrayList<>();
         for (final MavenProject mavenProject : reactorProjects) {
             if (shouldExclude(mavenProject)) {
-                getLog().info("Excluding " + mavenProject.getArtifactId());
+            	excludedProjects.add(mavenProject.getArtifactId());
                 continue;
             }
 
@@ -134,6 +136,8 @@ public class CycloneDxAggregateMojo extends CycloneDxMojo {
 
             projectDependencies.forEach(dependencies::putIfAbsent);
         }
+
+        excludedProjects.stream().sorted(String.CASE_INSENSITIVE_ORDER).forEach(excluded -> getLog().info("Excluding " + excluded));
 
         addMavenProjectsAsParentDependencies(reactorProjects, dependencies);
 

--- a/src/main/java/org/cyclonedx/maven/DefaultProjectDependenciesConverter.java
+++ b/src/main/java/org/cyclonedx/maven/DefaultProjectDependenciesConverter.java
@@ -40,10 +40,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -242,6 +244,7 @@ public class DefaultProjectDependenciesConverter implements ProjectDependenciesC
 
         // Check all BOM components have an associated BOM dependency
 
+        final List<String> notDepended = new ArrayList<>();
         for (Iterator<Map.Entry<String, Component>> it = components.entrySet().iterator(); it.hasNext(); ) {
             Map.Entry<String, Component> entry = it.next();
             if (!dependencies.containsKey(entry.getKey())) {
@@ -250,9 +253,11 @@ public class DefaultProjectDependenciesConverter implements ProjectDependenciesC
                 }
                 it.remove();
             } else if (!dependsOns.contains(entry.getKey())) {
-                logger.warn("BOM dependency listed but is not depended upon: " + entry.getKey());
+                notDepended.add(entry.getKey());
             }
         }
+
+        notDepended.stream().sorted(String.CASE_INSENSITIVE_ORDER).forEach(dependency -> logger.warn("BOM dependency listed but is not depended upon: " + dependency));
 
         // include BOM main component
         Component main = metadata.getComponent();


### PR DESCRIPTION
Sort the log output for excluded artifacts as well as not depended upon artifacts. That makes comparing multiple builds much easier than reading the "randomly sorted" looking output (it's not really random, but driven by the dependency order).

There is no functional change in which order the plugin iterates dependencies and calculates entries in the SBOM. Only the log output is sorted:

![grafik](https://github.com/user-attachments/assets/ad05d0c3-f69e-40e5-afb3-d358b46372d1)

fixes #541 

Side note: It's impossible to run integration tests behind a company proxy because of https://github.com/takari/takari-plugin-testing-project/issues/16