### PR TITLE
Avoid resources filtering warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -357,6 +357,15 @@
                     <artifactId>maven-project-info-reports-plugin</artifactId>
                     <version>3.6.1</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.3.1</version>
+                    <configuration>
+                        <!-- https://maven.apache.org/plugins/maven-resources-plugin/examples/filtering-properties-files.html -->
+                        <propertiesEncoding>UTF-8</propertiesEncoding>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
         <resources>


### PR DESCRIPTION
Since maven-resources 3.2.0 the encoding shall be specified explicitly. Avoids this console output:

[INFO] The encoding used to copy filtered properties files have not been set. This means that the same encoding will be used to copy filtered properties files as when copying other filtered resources. This might not be what you want! Run your build with --debug to see which files might be affected. Read more at
https://maven.apache.org/plugins/maven-resources-plugin/examples/filtering-properties-files.html