### PR TITLE
fix site issues created by upgrades #553 and #552

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -350,12 +350,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.20.0</version>
+                    <version>3.12.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>3.7.0</version>
+                    <version>3.6.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -3,7 +3,7 @@
     <skin>
         <groupId>org.apache.maven.skins</groupId>
         <artifactId>maven-fluido-skin</artifactId>
-        <version>1.10.0</version>
+        <version>1.12.0</version>
     </skin>
     <custom>
         <fluidoSkin>


### PR DESCRIPTION
maven-site-plugin 3.20.0 uses Doxia 2, need to stay with 3.1x
maven-project-info-reports-plugin 3.7.0 has an API issue