### PR TITLE
add IT for shipped/included dependencies vs not-shipped

### DIFF
--- a/src/it/shipped-or-not-deps/README.md
+++ b/src/it/shipped-or-not-deps/README.md
@@ -1,0 +1,39 @@
+SBOM Representation of Shipped vs Not-Shipped Dependencies
+====
+
+This IT is a WIP that for now show concrete issue before we can work on finding solutions then implement them.
+
+## What is the Problem
+
+- the [SBOM for `lib`](target/its/shipped-or-not-deps/not-shipped/lib/target/) has 4 dependencies
+- the [SBOM for `war`](target/its/shipped-or-not-deps/shipped/war/target/) has 5 (because it depends on `lib`)
+
+nothing in the 2 SBOMs shows that:
+- `war` **embeds** the dependencies (in `WEB-INF/lib/*.jar`), which in addition force a precise dependencies version if someone uses the `.war` file
+- but `lib` does not embed any dependency, just has soft references that will have to be resolved by a consumer, eventually changing the resolved version vs what was defined by the lib
+
+shade is like war, but just in more complex forms because there are many options
+
+Spring Boot is like war
+
+key differences between `shade`, `war` and Spring Boot is that the dependencies are not embedded exactly in the same location in the output artifact
+
+## Why does it Matter?
+
+When a library ships an SBOM that declares many dependencies, and a dependency has a vulnerability,
+users tend to report and ask "for a fixed library": upgrading the dependency by the consumer is natural,
+no absolute need for the provider to ship a new release of his library (unless compatibility with newer
+versions of the dependency is not easy).
+
+When a war or equivalent ships a dependency, consumer of the war cannot easily upgrade: it would require patching the
+war. Here, reporting the dependency vulnerability makes sense.
+
+If nothing is clear in the SBOM, end users cannot know what they should do: report or not?
+
+## Ideas
+
+- version-less component for library dependencies, to show that version from lib is just a hint, but consumer may change when doing conflict resolution,
+- CycloneDX 1.7 [`versionRange` and `isExternal`](https://cyclonedx.org/docs/1.7/json/#metadata_tools_oneOf_i0_components_items_versionRange), 
+- when a dependency is shipped, describe precisely where it is shipped, perhaps as `evidence` field,
+- based on previous shipped case, expand to a way to describe "not shipped"
+- ...

--- a/src/it/shipped-or-not-deps/not-shipped/lib/pom.xml
+++ b/src/it/shipped-or-not-deps/not-shipped/lib/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  This file is part of CycloneDX Maven Plugin.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) OWASP Foundation. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.cyclonedx.its</groupId>
+        <artifactId>not-shipped</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>lib</artifactId>
+
+    <name>not shipped dependencies: library</name>
+    <description>Dependencies are purely references, that will be resolved by consumer and eventually version changed.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId><!-- has 3 non-optional transitives: https://commons.apache.org/proper/commons-compress/dependencies.html -->
+            <version>1.27.1</version><!-- based on consumer context, another version may be really used when lib is used:
+               this is just version at build time, and default version for consume time if no version conflict resolution or dependencyManagement -->
+        </dependency>
+    </dependencies>
+</project>

--- a/src/it/shipped-or-not-deps/not-shipped/pom.xml
+++ b/src/it/shipped-or-not-deps/not-shipped/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  This file is part of CycloneDX Maven Plugin.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) OWASP Foundation. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.cyclonedx.its</groupId>
+        <artifactId>shipped-or-not-deps</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>not-shipped</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+      <module>lib</module>
+      <module>scope</module>
+      <!--module>optional</module-->
+    </modules>
+</project>

--- a/src/it/shipped-or-not-deps/not-shipped/scope/pom.xml
+++ b/src/it/shipped-or-not-deps/not-shipped/scope/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  This file is part of CycloneDX Maven Plugin.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) OWASP Foundation. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.cyclonedx.its</groupId>
+        <artifactId>not-shipped</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>scope</artifactId>
+
+    <name>not shipped dependencies: non-default scoped deps</name>
+    <description>test, runtime, provided: read https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Scope</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope><!-- only availalbe during tests copilation and run, but not main code compilation -->
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.26.0</version>
+            <scope>runtime</scope><!-- not even available at compile time, just during tests execution -->
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>4.0.2</version>
+            <scope>provided</scope><!-- runtime environment provides it: for example JavaEE/JakartaEE APIs, Maven core internals, Jenkins runner internals, ... -->
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>3.9.9</version>
+            <scope>provided</scope><!-- runtime environment provides it: for example JavaEE/JakartaEE APIs, Maven core internals, Jenkins runner internals, ... -->
+        </dependency>
+    </dependencies>
+</project>

--- a/src/it/shipped-or-not-deps/pom.xml
+++ b/src/it/shipped-or-not-deps/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  This file is part of CycloneDX Maven Plugin.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) OWASP Foundation. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.cyclonedx.its</groupId>
+    <artifactId>shipped-or-not-deps</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>Issue #589: Example of shipped dependencies vs non-shipped dependencies</name>
+    <description></description>
+    <url>https://github.com/CycloneDX/cyclonedx-maven-plugin</url>
+
+    <inceptionYear>2017</inceptionYear>
+    <organization>
+        <name>OWASP Foundation</name>
+        <url>https://owasp.org/</url>
+    </organization>
+
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <scm>
+        <connection>scm:git:git@github.com:CycloneDX/cyclonedx-maven-plugin.git</connection>
+        <url>https://github.com/CycloneDX/cyclonedx-maven-plugin.git</url>
+        <developerConnection>scm:git:git@github.com:CycloneDX/cyclonedx-maven-plugin.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/CycloneDX/cyclonedx-maven-plugin/issues</url>
+    </issueManagement>
+
+    <ciManagement>
+        <system>GitHub</system>
+        <url>https://github.com/CycloneDX/cyclonedx-maven-plugin/actions</url>
+    </ciManagement>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <modules>
+        <module>shipped</module>
+        <module>not-shipped</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>cyclonedx-makeAggregateBom</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>makeAggregateBom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/shipped-or-not-deps/shipped/pom.xml
+++ b/src/it/shipped-or-not-deps/shipped/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  This file is part of CycloneDX Maven Plugin.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) OWASP Foundation. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.cyclonedx.its</groupId>
+        <artifactId>shipped-or-not-deps</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>shipped</artifactId>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>war</module>
+        <!--module>assembly</module>
+        <module>excludes</module>
+        <module>shade-full</module>
+        <module>shade-partial</module>
+        <module>executable</module-->
+    </modules>
+</project>

--- a/src/it/shipped-or-not-deps/shipped/pom.xml
+++ b/src/it/shipped-or-not-deps/shipped/pom.xml
@@ -31,6 +31,9 @@
 
     <modules>
         <module>war</module>
+        <module>springboot</module>
+        <module>springboot-jetty</module>
+        <module>springboot-undertow</module>
         <!--module>assembly</module>
         <module>excludes</module>
         <module>shade-full</module>

--- a/src/it/shipped-or-not-deps/shipped/shade/fatjar-attach/pom.xml
+++ b/src/it/shipped-or-not-deps/shipped/shade/fatjar-attach/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  This file is part of CycloneDX Maven Plugin.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) OWASP Foundation. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.cyclonedx.its</groupId>
+        <artifactId>shade</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>fatjar-attach</artifactId>
+
+    <name>shipped dependencies: shade fat jar attached as additional artifact</name>
+    <description>Maven Shade Plugin creates a fat jar attached as an additional artifact with classifier 'all'.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.cyclonedx.its</groupId>
+            <artifactId>lib</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.18.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Attaches the shaded jar as an additional artifact instead of replacing the main one -->
+                            <!-- https://maven.apache.org/plugins/maven-shade-plugin/examples/attached-artifact.html -->
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>all</shadedClassifierName>
+                            <!-- exclude a few dependencies: https://maven.apache.org/plugins/maven-shade-plugin/examples/includes-excludes.html -->
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>commons-codec:*</exclude>
+                                </excludes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/shipped-or-not-deps/shipped/shade/fatjar-replace/pom.xml
+++ b/src/it/shipped-or-not-deps/shipped/shade/fatjar-replace/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  This file is part of CycloneDX Maven Plugin.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) OWASP Foundation. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.cyclonedx.its</groupId>
+        <artifactId>shade</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>fatjar-replace</artifactId>
+
+    <name>shipped dependencies: shade fat jar replacing the main artifact</name>
+    <description>Maven Shade Plugin creates a fat jar that replaces the main artifact.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.cyclonedx.its</groupId>
+            <artifactId>lib</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.18.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Default behavior: shaded jar replaces the main artifact -->
+                            <!-- exclude a few dependencies: https://maven.apache.org/plugins/maven-shade-plugin/examples/includes-excludes.html -->
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>commons-codec:*</exclude>
+                                </excludes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/shipped-or-not-deps/shipped/shade/partial-shade/pom.xml
+++ b/src/it/shipped-or-not-deps/shipped/shade/partial-shade/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  This file is part of CycloneDX Maven Plugin.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) OWASP Foundation. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.cyclonedx.its</groupId>
+        <artifactId>shade</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>partial-shade</artifactId>
+
+    <name>shipped dependencies: shade with partial shading</name>
+    <description>Maven Shade Plugin shades only specific classes, replacing the main artifact.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.cyclonedx.its</groupId>
+            <artifactId>lib</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.18.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Shade only specific packages/classes -->
+                            <!-- https://maven.apache.org/plugins/maven-shade-plugin/examples/class-relocation.html -->
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.commons.codec</pattern>
+                                    <shadedPattern>shaded.org.apache.commons.codec</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <!-- include a few dependencies: https://maven.apache.org/plugins/maven-shade-plugin/examples/includes-excludes.html -->
+                            <artifactSet>
+                                <includes>
+                                    <include>commons-codec:*</include>
+                                </includes>
+                            </artifactSet>
+
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/shipped-or-not-deps/shipped/shade/pom.xml
+++ b/src/it/shipped-or-not-deps/shipped/shade/pom.xml
@@ -23,20 +23,18 @@
 
     <parent>
         <groupId>org.cyclonedx.its</groupId>
-        <artifactId>shipped-or-not-deps</artifactId>
+        <artifactId>shipped</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>
-    <artifactId>shipped</artifactId>
+    <artifactId>shade</artifactId>
     <packaging>pom</packaging>
 
+    <name>shipped dependencies: maven-shade-plugin examples</name>
+    <description>Examples of maven-shade-plugin usage showing different shading strategies.</description>
+
     <modules>
-        <module>war</module>
-        <module>springboot</module>
-        <module>springboot-jetty</module>
-        <module>springboot-undertow</module>
-        <module>shade</module>
-        <!--module>assembly</module>
-        <module>excludes</module>
-        <module>executable</module-->
+        <module>fatjar-replace</module>
+        <module>fatjar-attach</module>
+        <module>partial-shade</module>
     </modules>
 </project>

--- a/src/it/shipped-or-not-deps/shipped/springboot-jetty/pom.xml
+++ b/src/it/shipped-or-not-deps/shipped/springboot-jetty/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  This file is part of CycloneDX Maven Plugin.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) OWASP Foundation. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.cyclonedx.its</groupId>
+        <artifactId>shipped</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>sprinboot-jetty</artifactId>
+    <packaging>war</packaging><!-- https://maven.apache.org/ref/3.9.9/maven-core/default-bindings.html#Plugin_bindings_for_war_packaging invokes maven-war-plugin -->
+
+    <name>shipped dependencies: springboot-jetty war</name>
+    <description>Maven War Plugin copies shipped dependencies to WEB-INF/lib/ as per war spec.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-tomcat</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jetty</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.cyclonedx.its</groupId>
+            <artifactId>lib</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.18.0</version><!-- force a version for transitive of lib because Maven conflict resolution = nearest wins -->
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <!-- Import dependency management from Spring Boot -->
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>2.1.18.RELEASE</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.1.18.RELEASE</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/shipped-or-not-deps/shipped/springboot-undertow/pom.xml
+++ b/src/it/shipped-or-not-deps/shipped/springboot-undertow/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  This file is part of CycloneDX Maven Plugin.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) OWASP Foundation. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.cyclonedx.its</groupId>
+        <artifactId>shipped</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>sprinboot-undertow</artifactId>
+    <packaging>war</packaging><!-- https://maven.apache.org/ref/3.9.9/maven-core/default-bindings.html#Plugin_bindings_for_war_packaging invokes maven-war-plugin -->
+
+    <name>shipped dependencies: springboot-undertow war</name>
+    <description>Maven War Plugin copies shipped dependencies to WEB-INF/lib/ as per war spec.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-tomcat</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-undertow</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.cyclonedx.its</groupId>
+            <artifactId>lib</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.18.0</version><!-- force a version for transitive of lib because Maven conflict resolution = nearest wins -->
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <!-- Import dependency management from Spring Boot -->
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>2.1.18.RELEASE</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.1.18.RELEASE</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/shipped-or-not-deps/shipped/springboot/pom.xml
+++ b/src/it/shipped-or-not-deps/shipped/springboot/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  This file is part of CycloneDX Maven Plugin.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) OWASP Foundation. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.cyclonedx.its</groupId>
+        <artifactId>shipped</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>sprinboot</artifactId>
+    <packaging>war</packaging><!-- https://maven.apache.org/ref/3.9.9/maven-core/default-bindings.html#Plugin_bindings_for_war_packaging invokes maven-war-plugin -->
+
+    <name>shipped dependencies: springboot war</name>
+    <description>Maven War Plugin copies shipped dependencies to WEB-INF/lib/ as per war spec.</description>
+
+    <dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+        <dependency>
+            <groupId>org.cyclonedx.its</groupId>
+            <artifactId>lib</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.18.0</version><!-- force a version for transitive of lib because Maven conflict resolution = nearest wins -->
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <!-- Import dependency management from Spring Boot -->
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>2.1.18.RELEASE</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.1.18.RELEASE</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/shipped-or-not-deps/shipped/war/pom.xml
+++ b/src/it/shipped-or-not-deps/shipped/war/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  This file is part of CycloneDX Maven Plugin.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) OWASP Foundation. All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.cyclonedx.its</groupId>
+        <artifactId>shipped</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>war</artifactId>
+    <packaging>war</packaging><!-- https://maven.apache.org/ref/3.9.9/maven-core/default-bindings.html#Plugin_bindings_for_war_packaging invokes maven-war-plugin -->
+
+    <name>shipped dependencies: war</name>
+    <description>Maven War Plugin copies shipped dependencies to WEB-INF/lib/ as per war spec.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.cyclonedx.its</groupId>
+            <artifactId>lib</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.18.0</version><!-- force a version for transitive of lib because Maven conflict resolution = nearest wins -->
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement><!-- force a version for transitives -->
+        <dependencies>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.18.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/src/it/shipped-or-not-deps/shipped/war/src/main/webapp/WEB-INF/web.xml
+++ b/src/it/shipped-or-not-deps/shipped/war/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
+
+<web-app >
+</web-app>


### PR DESCRIPTION
see #589 
this PR is not yet about changing anything to generated CycloneDX documents, but listing all cases:
- from the most basic =
  -  classical libraries that have transitive dependences = not shipped
  - classical war files = ship dependencies in `WEB-INF/lib` in `.war` archive
- to most advanced =
  - shade: very flexible, including partial ship
  - assembly: very flexible configuration file
  - executable archives: ship dependencies, but also adds a launcher (that may even bring a servlet container like Tomcat or Jetty, that is not even listed as a dependency)

see also #576 for a first pass