### PR TITLE
Handle central-publishing-maven-plugin for skipNotDeployed detection

### DIFF
--- a/src/it/makeAggregateBom/central-publishing-maven-plugin/pom.xml
+++ b/src/it/makeAggregateBom/central-publishing-maven-plugin/pom.xml
@@ -26,17 +26,28 @@
         <artifactId>makeAggregateBom</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>
-    <artifactId>skipped</artifactId>
-    <packaging>pom</packaging>
+    <artifactId>central-publishing-maven-plugin</artifactId>
 
-    <modules>
-      <module>central-publishing-maven-plugin-config</module>
-      <module>central-publishing-maven-plugin-property</module>
-      <module>deploy-property</module>
-      <module>deploy-property-force</module>
-      <module>deploy-config</module>
-      <module>deploy-config-force</module>
-      <module>nexus-property</module>
-      <module>nexus-config</module>
-    </modules>
+    <dependencies>
+        <dependency>
+            <groupId>org.cyclonedx</groupId>
+            <artifactId>cyclonedx-core-java</artifactId>
+            <version>9.0.5</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+    <plugins>
+        <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.7.0</version>
+            <extensions>true</extensions>
+            <configuration>
+                <publishingServerId>central</publishingServerId>
+                <autoPublish>true</autoPublish>
+            </configuration>
+        </plugin>
+</plugins>
+    </build>
 </project>

--- a/src/it/makeAggregateBom/pom.xml
+++ b/src/it/makeAggregateBom/pom.xml
@@ -78,6 +78,7 @@
 
     <modules>
         <module>api</module>
+        <module>central-publishing-maven-plugin</module>
         <module>impls</module>
         <module>skipped</module>
         <module>util</module>

--- a/src/it/makeAggregateBom/skipped/central-publishing-maven-plugin-config/pom.xml
+++ b/src/it/makeAggregateBom/skipped/central-publishing-maven-plugin-config/pom.xml
@@ -23,20 +23,32 @@
 
     <parent>
         <groupId>org.cyclonedx.its</groupId>
-        <artifactId>makeAggregateBom</artifactId>
+        <artifactId>skipped</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>
-    <artifactId>skipped</artifactId>
-    <packaging>pom</packaging>
+    <artifactId>central-publishing-maven-plugin-config</artifactId>
 
-    <modules>
-      <module>central-publishing-maven-plugin-config</module>
-      <module>central-publishing-maven-plugin-property</module>
-      <module>deploy-property</module>
-      <module>deploy-property-force</module>
-      <module>deploy-config</module>
-      <module>deploy-config-force</module>
-      <module>nexus-property</module>
-      <module>nexus-config</module>
-    </modules>
+    <dependencies>
+        <dependency>
+            <groupId>org.cyclonedx</groupId>
+            <artifactId>cyclonedx-core-java</artifactId>
+            <version>9.0.5</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+    <plugins>
+        <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.7.0</version>
+            <extensions>true</extensions>
+            <configuration>
+                <publishingServerId>central</publishingServerId>
+                <autoPublish>true</autoPublish>
+                <skipPublishing>true</skipPublishing>
+            </configuration>
+        </plugin>
+</plugins>
+    </build>
 </project>

--- a/src/it/makeAggregateBom/skipped/central-publishing-maven-plugin-property/pom.xml
+++ b/src/it/makeAggregateBom/skipped/central-publishing-maven-plugin-property/pom.xml
@@ -23,20 +23,35 @@
 
     <parent>
         <groupId>org.cyclonedx.its</groupId>
-        <artifactId>makeAggregateBom</artifactId>
+        <artifactId>skipped</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>
-    <artifactId>skipped</artifactId>
-    <packaging>pom</packaging>
+    <artifactId>central-publishing-maven-plugin-property</artifactId>
 
-    <modules>
-      <module>central-publishing-maven-plugin-config</module>
-      <module>central-publishing-maven-plugin-property</module>
-      <module>deploy-property</module>
-      <module>deploy-property-force</module>
-      <module>deploy-config</module>
-      <module>deploy-config-force</module>
-      <module>nexus-property</module>
-      <module>nexus-config</module>
-    </modules>
+    <dependencies>
+        <dependency>
+            <groupId>org.cyclonedx</groupId>
+            <artifactId>cyclonedx-core-java</artifactId>
+            <version>9.0.5</version>
+        </dependency>
+    </dependencies>
+    
+    <properties>
+       <skipPublishing>true</skipPublishing>
+    </properties>
+
+    <build>
+    <plugins>
+        <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.7.0</version>
+            <extensions>true</extensions>
+            <configuration>
+                <publishingServerId>central</publishingServerId>
+                <autoPublish>true</autoPublish>
+            </configuration>
+        </plugin>
+</plugins>
+    </build>
 </project>

--- a/src/it/makeAggregateBom/verify.groovy
+++ b/src/it/makeAggregateBom/verify.groovy
@@ -25,6 +25,7 @@ void assertNoBomFiles(String path) {
 
 assertBomFiles("target/bom", true) // aggregate
 assertBomFiles("api/target/bom", false)
+assertBomFiles("central-publishing-maven-plugin/target/bom", false)
 assertBomFiles("util/target/bom", false)
 assertBomFiles("impls/target/bom", false)
 assertBomFiles("impls/impl-A/target/bom", false)
@@ -33,6 +34,8 @@ assertBomFiles("skipped/target/bom", false)
 assertBomFiles("skipped/deploy-config-force/target/bom", false)
 assertBomFiles("skipped/deploy-property-force/target/bom", false)
 
+assertNoBomFiles("skipped/central-publishing-maven-plugin-config/target/bom")
+assertNoBomFiles("skipped/central-publishing-maven-plugin-property/target/bom")
 assertNoBomFiles("skipped/deploy-config/target/bom")
 assertNoBomFiles("skipped/deploy-property/target/bom")
 assertNoBomFiles("skipped/nexus-config/target/bom")
@@ -40,16 +43,16 @@ assertNoBomFiles("skipped/nexus-property/target/bom")
 
 var buildLog = new File(basedir, "build.log").text
 
-assert 17 == (buildLog =~ /\[INFO\] CycloneDX: Resolving Dependencies/).size()
+assert 19 == (buildLog =~ /\[INFO\] CycloneDX: Resolving Dependencies/).size()
 assert 2 == (buildLog =~ /\[INFO\] CycloneDX: Resolving Aggregated Dependencies/).size()
 
-// 19 = 9 modules for main cyclonedx-makeAggregateBom execution
+// 21 = 10 modules for main cyclonedx-makeAggregateBom execution
 //    + 1 for root module cyclonedx-makeAggregateBom-root-only execution
-//    + 9 modules for additional cyclonedx-makeBom execution
-assert 19 == (buildLog =~ /\[INFO\] CycloneDX: Writing and validating BOM \(XML\)/).size()
-assert 19 == (buildLog =~ /\[INFO\] CycloneDX: Writing and validating BOM \(JSON\)/).size()
-// cyclonedx-makeAggregateBom-root-only execution skips 7 non-root modules
-assert 8 == (buildLog =~ /\[INFO\] Skipping CycloneDX on non-execution root/).size()
+//    + 10 modules for additional cyclonedx-makeBom execution
+assert 21 == (buildLog =~ /\[INFO\] CycloneDX: Writing and validating BOM \(XML\)/).size()
+assert 21 == (buildLog =~ /\[INFO\] CycloneDX: Writing and validating BOM \(JSON\)/).size()
+// cyclonedx-makeAggregateBom-root-only execution skips 9 non-root modules
+assert 9 == (buildLog =~ /\[INFO\] Skipping CycloneDX on non-execution root/).size()
 
 // [WARNING] artifact org.cyclonedx.its:api:xml:cyclonedx:1.0-SNAPSHOT already attached, replace previous instance
 assert 0 == (buildLog =~ /-SNAPSHOT already attached, replace previous instance/).size()
@@ -84,4 +87,4 @@ assert rootDependencies.contains('<dependency ref="pkg:maven/org.cyclonedx.its/a
 assert rootDependencies.contains('<dependency ref="pkg:maven/org.cyclonedx.its/impls@1.0-SNAPSHOT?type=pom"/>')
 assert rootDependencies.contains('<dependency ref="pkg:maven/org.cyclonedx.its/util@1.0-SNAPSHOT?type=jar"/>')
 assert rootDependencies.contains('<dependency ref="pkg:maven/org.cyclonedx.its/skipped@1.0-SNAPSHOT?type=pom"/>')
-assert 5 == (rootDependencies =~ /<dependency ref="pkg:maven/).size()
+assert 6 == (rootDependencies =~ /<dependency ref="pkg:maven/).size()

--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -273,6 +273,7 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
      */
     private static final String MAVEN_DEPLOY_PLUGIN = "org.apache.maven.plugins:maven-deploy-plugin";
     private static final String NEXUS_STAGING_PLUGIN = "org.sonatype.plugins:nexus-staging-maven-plugin";
+    private static final String CENTRAL_PUBLISHING_PLUGIN = "org.sonatype.central:central-publishing-maven-plugin";
 
     /**
      * Returns a reference to the current project.
@@ -605,17 +606,25 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
         return isDeployable(project,
                         MAVEN_DEPLOY_PLUGIN,
                         "skip",
-                        "maven.deploy.skip")
+                        "maven.deploy.skip",
+                        "deploy")
                 || isDeployable(project,
                         NEXUS_STAGING_PLUGIN,
                         "skipNexusStagingDeployMojo",
-                        "skipNexusStagingDeployMojo");
+                        "skipNexusStagingDeployMojo",
+                        "deploy")
+                || isDeployable(project,
+                        CENTRAL_PUBLISHING_PLUGIN,
+                        "skipPublishing",
+                        "skipPublishing",
+                        "publish");
     }
 
     private static boolean isDeployable(final MavenProject project,
                                         final String pluginKey,
                                         final String parameter,
-                                        final String propertyName) {
+                                        final String propertyName, 
+                                        final String goal) {
         final Plugin plugin = project.getPlugin(pluginKey);
         if (plugin != null) {
             // Default skip value
@@ -623,7 +632,7 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
             final boolean defaultSkipValue = property != null ? Boolean.parseBoolean(property) : false;
             // Find an execution that is not skipped
             for (final PluginExecution execution : plugin.getExecutions()) {
-                if (execution.getGoals().contains("deploy")) {
+                if (execution.getGoals().contains(goal)) {
                     final Xpp3Dom executionConf = (Xpp3Dom) execution.getConfiguration();
                     final Xpp3Dom target = (executionConf == null) ? null : executionConf.getChild(parameter);
                     final boolean skipValue = (target == null) ? defaultSkipValue : Boolean.parseBoolean(target.getValue());


### PR DESCRIPTION
this is the plugin replacing nexus-maven-plugin.
The goal used by this plugin is `publish` and not `deploy` as other ones 

we can notice on the output that it is `publish`, for instance from https://central.sonatype.org/publish/publish-portal-maven/#publishing

`[INFO] --- central-publishing-maven-plugin:0.7.0:publish (injected-central-publishing) @ example ---`

fix #597

---

Edit: this is about [`skipNotDeployed`](https://cyclonedx.github.io/cyclonedx-maven-plugin/makeAggregateBom-mojo.html#skipNotDeployed) detection #416 / #435 
central-publishing-maven-plugin configures all POMs as "maven-deploy-plugin skip" to replace the deployment mechanism: cyclonedx-maven-plugin needs to detect the use of central-publishing-maven-plugin to adapt its "skip" detection approach