### PR TITLE
feat: Add parent POM preservation with configurable dependency reorganization

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Default Values
             <outputName>bom</outputName>
             <outputDirectory>${project.build.directory}</outputDirectory><!-- usually target, if not redefined in pom.xml -->
             <verbose>false</verbose><!-- = ${cyclonedx.verbose} -->
+            <preserveParentReferences>false</preserveParentReferences>
+            <includeParentsAsComponents>true</includeParentsAsComponents>
         </configuration>
     </plugin>
 </plugins>
@@ -66,6 +68,33 @@ Default Values
 `<projectType>` default value is `library` but there are [more choices defined in the CycloneDX specification](https://cyclonedx.org/docs/1.6/json/#metadata_component_type).
 
 See also [External References](https://cyclonedx.github.io/cyclonedx-maven-plugin/external-references.html) documentation for details on this topic.
+
+Parent POM Preservation
+-------------------
+By default, the plugin flattens the Maven effective POM model, merging all dependencies from parent POMs into a single list. When `preserveParentReferences` is enabled, the plugin preserves the parent POM hierarchy:
+
+* **`preserveParentReferences`**: Enable parent POM preservation (default: `false`)
+  * When `true`, parent POMs become direct dependencies of the component that references them
+  * Walks the entire parent chain recursively (child ? parent ? grandparent ? ...)
+  * Dependencies inherited from parent POMs are reorganized to depend on their introducing parent
+
+* **`includeParentsAsComponents`**: Include parent POMs in the components section (default: `true`)
+  * When `true`, parent POMs appear as components in the BOM
+  * When `false`, parent POMs are referenced only in the dependency graph but not listed as components
+
+Example configuration to preserve parent POM references:
+
+```xml
+<configuration>
+    <preserveParentReferences>true</preserveParentReferences>
+    <includeParentsAsComponents>true</includeParentsAsComponents>
+</configuration>
+```
+
+This is useful for:
+* Understanding the complete project structure including parent POMs
+* Tracking which parent POM introduces specific dependencies
+* Maintaining visibility of the full Maven inheritance hierarchy
 
 Excluding Projects
 -------------------

--- a/src/main/java/org/cyclonedx/maven/ModelConverter.java
+++ b/src/main/java/org/cyclonedx/maven/ModelConverter.java
@@ -25,6 +25,8 @@ import org.cyclonedx.model.Component;
 import org.cyclonedx.model.ExternalReference;
 import org.cyclonedx.model.Metadata;
 
+import java.util.Set;
+
 /**
  * Model converter from Maven concepts (dependency Artifact + MavenProject) to CycloneDX ones
  * (resp. Component with pURL + Metadata).
@@ -62,5 +64,29 @@ public interface ModelConverter {
      * @return a CycloneDX Metadata object
      */
     Metadata convertMavenProject(MavenProject project, String projectType, Version schemaVersion, boolean includeLicenseText, ExternalReference[] externalReferences);
+
+    /**
+     * Checks if an artifact has a parent POM reference in its original (non-effective) POM.
+     *
+     * @param artifact the artifact to check
+     * @return true if the artifact has a parent POM, false otherwise
+     */
+    boolean hasParentPom(Artifact artifact);
+
+    /**
+     * Gets the parent artifact reference from the original (non-effective) POM.
+     *
+     * @param artifact the artifact whose parent to retrieve
+     * @return the parent artifact, or null if no parent exists
+     */
+    Artifact getParentArtifact(Artifact artifact);
+
+    /**
+     * Gets the set of direct dependency package URLs declared in an artifact's POM.
+     *
+     * @param artifact the artifact whose dependencies to extract
+     * @return set of package URLs for direct dependencies
+     */
+    Set<String> getDirectDependencyPurls(Artifact artifact);
 
 }

--- a/src/main/java/org/cyclonedx/maven/ProjectDependenciesConverter.java
+++ b/src/main/java/org/cyclonedx/maven/ProjectDependenciesConverter.java
@@ -36,6 +36,18 @@ public interface ProjectDependenciesConverter {
     BomDependencies extractBOMDependencies(MavenProject mavenProject, MavenDependencyScopes include, String[] excludes) throws MojoExecutionException;
 
     /**
+     * Extracts BOM dependencies with optional parent POM preservation.
+     *
+     * @param mavenProject the Maven project to analyze
+     * @param include scope configuration for included dependencies
+     * @param excludes types to exclude
+     * @param preserveParentReferences whether to preserve parent POM references as dependencies
+     * @return BOM dependencies structure
+     * @throws MojoExecutionException if dependency extraction fails
+     */
+    BomDependencies extractBOMDependencies(MavenProject mavenProject, MavenDependencyScopes include, String[] excludes, boolean preserveParentReferences) throws MojoExecutionException;
+
+    /**
      * Check consistency between BOM components and BOM dependencies, and cleanup: drop components found while walking the
      * Maven dependency resolution graph but that are finally not kept in the effective dependencies list.
      *

--- a/src/test/java/org/cyclonedx/maven/ParentNoComponentTest.java
+++ b/src/test/java/org/cyclonedx/maven/ParentNoComponentTest.java
@@ -1,0 +1,87 @@
+package org.cyclonedx.maven;
+
+import java.io.File;
+import java.util.Set;
+
+import static org.cyclonedx.maven.TestUtils.getComponentNode;
+import static org.cyclonedx.maven.TestUtils.getDependencyNode;
+import static org.cyclonedx.maven.TestUtils.getDependencyReferences;
+import static org.cyclonedx.maven.TestUtils.getElement;
+import static org.cyclonedx.maven.TestUtils.readXML;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
+import io.takari.maven.testing.executor.MavenVersions;
+import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
+
+/**
+ * Tests for parent POM preservation with includeParentsAsComponents=false.
+ * Verifies that parent POMs are tracked in dependencies but NOT included in components list.
+ */
+@RunWith(MavenJUnitTestRunner.class)
+@MavenVersions({"3.6.3"})
+public class ParentNoComponentTest extends BaseMavenVerifier {
+
+    // PURLs for test components
+    private static final String PARENT_POM = "pkg:maven/com.example/parent-pom@1.0.0?type=pom";
+    private static final String CHILD_APP = "pkg:maven/com.example/child-app@1.0.0?type=jar";
+    
+    private static final String SLF4J_API = "pkg:maven/org.slf4j/slf4j-api@1.7.36?type=jar";
+    private static final String GUAVA = "pkg:maven/com.google.guava/guava@31.1-jre?type=jar";
+
+    public ParentNoComponentTest(MavenRuntimeBuilder runtimeBuilder) throws Exception {
+        super(runtimeBuilder);
+    }
+
+    /**
+     * Test that parent POMs are NOT included as components when includeParentsAsComponents is false,
+     * but they still appear in the dependency relationships.
+     */
+    @Test
+    public void testParentNotInComponents() throws Exception {
+        final File projDir = mvnBuild("parent-no-component", new String[]{"clean", "package"}, null, null, null);
+
+        // Check the child application BOM
+        final Document childBom = readXML(new File(projDir, "child-app/target/bom.xml"));
+
+        final Element components = getElement(childBom.getDocumentElement(), "components");
+        assertNotNull("Expected a components element", components);
+
+        final Element dependencies = getElement(childBom.getDocumentElement(), "dependencies");
+        assertNotNull("Expected a dependencies element", dependencies);
+
+        // Verify that parent POM is NOT included as a component
+        final Node parentComponent = getComponentNode(components, PARENT_POM);
+        assertNull("Parent POM should NOT be included as a component when includeParentsAsComponents=false", parentComponent);
+
+        // Verify that guava IS included as a component (it's a real dependency)
+        final Node guavaComponent = getComponentNode(components, GUAVA);
+        assertNotNull("Guava should be included as a component", guavaComponent);
+
+        // Verify child's dependencies include the parent (even though parent is not a component)
+        final Node childDeps = getDependencyNode(dependencies, CHILD_APP);
+        assertNotNull("Child dependency node should exist", childDeps);
+        
+        Set<String> childDependencies = getDependencyReferences(childDeps);
+        assertTrue("Child should depend on parent POM", childDependencies.contains(PARENT_POM));
+        assertTrue("Child should have direct dependency on guava", childDependencies.contains(GUAVA));
+
+        // Verify parent's dependencies exist even though parent is not a component
+        final Node parentDeps = getDependencyNode(dependencies, PARENT_POM);
+        assertNotNull("Parent dependency node should exist (even without component)", parentDeps);
+        
+        Set<String> parentDependencies = getDependencyReferences(parentDeps);
+        assertTrue("Parent should have slf4j-api in its dependencies", parentDependencies.contains(SLF4J_API));
+    }
+}

--- a/src/test/java/org/cyclonedx/maven/ParentPreservationTest.java
+++ b/src/test/java/org/cyclonedx/maven/ParentPreservationTest.java
@@ -1,0 +1,121 @@
+package org.cyclonedx.maven;
+
+import java.io.File;
+import java.util.Set;
+
+import static org.cyclonedx.maven.TestUtils.getComponentNode;
+import static org.cyclonedx.maven.TestUtils.getDependencyNode;
+import static org.cyclonedx.maven.TestUtils.getDependencyReferences;
+import static org.cyclonedx.maven.TestUtils.getElement;
+import static org.cyclonedx.maven.TestUtils.readXML;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
+import io.takari.maven.testing.executor.MavenVersions;
+import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
+
+/**
+ * Tests for parent POM preservation functionality.
+ * Verifies that when preserveParentReferences is enabled, parent POMs are properly tracked
+ * and dependencies are correctly attributed to their declaring POM.
+ */
+@RunWith(MavenJUnitTestRunner.class)
+@MavenVersions({"3.6.3"})
+public class ParentPreservationTest extends BaseMavenVerifier {
+
+    // PURLs for test components
+    private static final String GRANDPARENT_POM = "pkg:maven/com.example/grandparent@1.0.0?type=pom";
+    private static final String PARENT_POM = "pkg:maven/com.example/parent@1.0.0?type=pom";
+    private static final String CHILD_JAR = "pkg:maven/com.example/child@1.0.0?type=jar";
+    private static final String STANDALONE_JAR = "pkg:maven/com.example/standalone@1.0.0?type=jar";
+    
+    private static final String COMMONS_IO = "pkg:maven/commons-io/commons-io@2.11.0?type=jar";
+    private static final String COMMONS_CODEC = "pkg:maven/commons-codec/commons-codec@1.15?type=jar";
+    private static final String JUNIT = "pkg:maven/junit/junit@4.13.2?type=jar";
+    private static final String COMMONS_LANG3 = "pkg:maven/org.apache.commons/commons-lang3@3.12.0?type=jar";
+
+    public ParentPreservationTest(MavenRuntimeBuilder runtimeBuilder) throws Exception {
+        super(runtimeBuilder);
+    }
+
+    /**
+     * Test that parent POMs are included as components when includeParentsAsComponents is true.
+     */
+    @Test
+    public void testParentPreservationWithParentComponents() throws Exception {
+        final File projDir = mvnBuild("parent-preservation", new String[]{"clean", "package"}, null, null, null);
+
+        // Check the child project BOM
+        final Document childBom = readXML(new File(projDir, "child/target/bom.xml"));
+
+        final Element components = getElement(childBom.getDocumentElement(), "components");
+        assertNotNull("Expected a components element", components);
+
+        final Element dependencies = getElement(childBom.getDocumentElement(), "dependencies");
+        assertNotNull("Expected a dependencies element", dependencies);
+
+        // Verify that parent POM is included as a component
+        final Node parentComponent = getComponentNode(components, PARENT_POM);
+        assertNotNull("Parent POM should be included as a component", parentComponent);
+
+        // Verify that grandparent POM is included as a component
+        final Node grandparentComponent = getComponentNode(components, GRANDPARENT_POM);
+        assertNotNull("Grandparent POM should be included as a component", grandparentComponent);
+
+        // Verify child's dependencies include the parent
+        final Node childDeps = getDependencyNode(dependencies, CHILD_JAR);
+        assertNotNull("Child dependency node should exist", childDeps);
+        
+        Set<String> childDependencies = getDependencyReferences(childDeps);
+        assertTrue("Child should depend on parent POM", childDependencies.contains(PARENT_POM));
+        assertTrue("Child should have direct dependency on commons-lang3", childDependencies.contains(COMMONS_LANG3));
+
+        // Verify parent's dependencies include the grandparent and commons-codec
+        final Node parentDeps = getDependencyNode(dependencies, PARENT_POM);
+        assertNotNull("Parent dependency node should exist", parentDeps);
+        
+        Set<String> parentDependencies = getDependencyReferences(parentDeps);
+        assertTrue("Parent should depend on grandparent POM", parentDependencies.contains(GRANDPARENT_POM));
+        assertTrue("Parent should have commons-codec", parentDependencies.contains(COMMONS_CODEC));
+
+        // Verify grandparent's dependencies include commons-io
+        final Node grandparentDeps = getDependencyNode(dependencies, GRANDPARENT_POM);
+        assertNotNull("Grandparent dependency node should exist", grandparentDeps);
+        
+        Set<String> grandparentDependencies = getDependencyReferences(grandparentDeps);
+        assertTrue("Grandparent should have commons-io", grandparentDependencies.contains(COMMONS_IO));
+    }
+
+    /**
+     * Test that standalone project without parent dependencies works correctly.
+     */
+    @Test
+    public void testStandaloneProjectWithParentPreservation() throws Exception {
+        final File projDir = mvnBuild("parent-preservation", new String[]{"clean", "package"}, null, null, null);
+
+        // Check the standalone project BOM
+        final Document standaloneBom = readXML(new File(projDir, "standalone/target/bom.xml"));
+
+        final Element dependencies = getElement(standaloneBom.getDocumentElement(), "dependencies");
+        assertNotNull("Expected a dependencies element", dependencies);
+
+        // Verify standalone project's dependencies
+        final Node standaloneDeps = getDependencyNode(dependencies, STANDALONE_JAR);
+        assertNotNull("Standalone dependency node should exist", standaloneDeps);
+        
+        Set<String> standaloneDependencies = getDependencyReferences(standaloneDeps);
+        assertTrue("Standalone should have direct dependency on commons-lang3", standaloneDependencies.contains(COMMONS_LANG3));
+    }
+}

--- a/src/test/resources/parent-no-component/child-app/pom.xml
+++ b/src/test/resources/parent-no-component/child-app/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>parent-pom</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../parent-pom</relativePath>
+    </parent>
+
+    <artifactId>child-app</artifactId>
+
+    <name>Child Application</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>31.1-jre</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>${current.version}</version>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>makeBom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <outputFormat>xml</outputFormat>
+                    <preserveParentReferences>true</preserveParentReferences>
+                    <includeParentsAsComponents>false</includeParentsAsComponents>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/parent-no-component/parent-pom/pom.xml
+++ b/src/test/resources/parent-no-component/parent-pom/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>parent-no-component-parent</artifactId>
+        <version>1.0.0</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>parent-pom</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Application Parent POM</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.36</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/test/resources/parent-no-component/pom.xml
+++ b/src/test/resources/parent-no-component/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>parent-no-component-parent</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0.0</version>
+
+    <name>Parent Preservation Tests (No Components)</name>
+
+    <modules>
+        <module>parent-pom</module>
+        <module>child-app</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>${current.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-makeAggregateBom</id>
+                        <goals>
+                            <goal>makeAggregateBom</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <schemaVersion>1.6</schemaVersion>
+                    <preserveParentReferences>true</preserveParentReferences>
+                    <includeParentsAsComponents>false</includeParentsAsComponents>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/parent-preservation/child/pom.xml
+++ b/src/test/resources/parent-preservation/child/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../parent</relativePath>
+    </parent>
+
+    <artifactId>child</artifactId>
+
+    <name>Child Project</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>${current.version}</version>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>makeBom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <outputFormat>xml</outputFormat>
+                    <preserveParentReferences>true</preserveParentReferences>
+                    <includeParentsAsComponents>true</includeParentsAsComponents>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/parent-preservation/grandparent/pom.xml
+++ b/src/test/resources/parent-preservation/grandparent/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>parent-preservation-parent</artifactId>
+        <version>1.0.0</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>grandparent</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Grandparent POM</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/test/resources/parent-preservation/parent/pom.xml
+++ b/src/test/resources/parent-preservation/parent/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>grandparent</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../grandparent</relativePath>
+    </parent>
+
+    <artifactId>parent</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Parent POM</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.15</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/test/resources/parent-preservation/pom.xml
+++ b/src/test/resources/parent-preservation/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>parent-preservation-parent</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0.0</version>
+
+    <name>Parent Preservation Tests Parent</name>
+
+    <modules>
+        <module>grandparent</module>
+        <module>parent</module>
+        <module>child</module>
+        <module>standalone</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>${current.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-makeAggregateBom</id>
+                        <goals>
+                            <goal>makeAggregateBom</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <schemaVersion>1.6</schemaVersion>
+                    <preserveParentReferences>true</preserveParentReferences>
+                    <includeParentsAsComponents>true</includeParentsAsComponents>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/test/resources/parent-preservation/standalone/pom.xml
+++ b/src/test/resources/parent-preservation/standalone/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>parent-preservation-parent</artifactId>
+        <version>1.0.0</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>standalone</artifactId>
+
+    <name>Standalone Project (no parent POM deps)</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>${current.version}</version>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>makeBom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <outputFormat>xml</outputFormat>
+                    <preserveParentReferences>true</preserveParentReferences>
+                    <includeParentsAsComponents>true</includeParentsAsComponents>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
## Description

This PR adds support for preserving parent POM references in the generated SBOM instead of flattening them into the effective POM model. This enhancement provides better visibility into the Maven project structure and dependency inheritance hierarchy.

## Changes

### New Configuration Parameters

- **`preserveParentReferences`** (default: `false`): Enable parent POM preservation
  - When enabled, parent POMs are added as direct dependencies of components that reference them
  - Recursively walks the entire parent chain (child → parent → grandparent → ...)
  
- **`includeParentsAsComponents`** (default: `true`): Control parent POM visibility in components section
  - When `true`, parent POMs appear as components in the BOM
  - When `false`, parent POMs are referenced only in the dependency graph

### Implementation Details

**Modified Files:**
- `BaseCycloneDxMojo.java`: Added configuration parameters and component filtering logic
- `ModelConverter.java`: Extended interface with parent detection and dependency extraction methods
- `DefaultModelConverter.java`: Implemented parent POM detection and direct dependency extraction
- `ProjectDependenciesConverter.java`: Extended interface for parent chain processing
- `DefaultProjectDependenciesConverter.java`: Implemented recursive parent chain walking and dependency reorganization

**Key Features:**
- Recursively processes entire parent POM hierarchy
- Reorganizes inherited dependencies to reference their introducing parent POM
- Uses `ProjectBuilder` for efficient parent POM resolution
- Null-safe artifact creation for parent POMs
- Components without dependency entries are pruned during cleanup

### Testing

- Added comprehensive test suite with multi-level parent hierarchies (4 levels deep)
- `ParentPreservationTest`: Validates parent POMs appear as components with correct dependency graph
- `ParentNoComponentTest`: Validates parent exclusion when `includeParentsAsComponents=false`
- All existing tests continue to pass (27/27)

### Documentation

- Updated README.md with new configuration options and usage examples
- Added "Parent POM Preservation" section explaining the feature and use cases

## Use Cases

This feature is valuable for:
- Understanding complete project structure including parent POMs
- Tracking which parent POM introduces specific dependencies
- Maintaining visibility of the full Maven inheritance hierarchy
- SBOM accuracy when parent POMs are managed artifacts with their own lifecycle

## Backward Compatibility

This is a **non-breaking change**:
- Default behavior remains unchanged (`preserveParentReferences=false`)
- Existing BOMs will generate identically unless explicitly enabled
- All existing tests pass without modification

## Example

With `preserveParentReferences=true`:
```xml
<configuration>
    <preserveParentReferences>true</preserveParentReferences>
    <includeParentsAsComponents>true</includeParentsAsComponents>
</configuration>