### PR TITLE
Configurable pretty printing of SBOMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Default Values
             <outputFormat>all</outputFormat>
             <outputName>bom</outputName>
             <outputDirectory>${project.build.directory}</outputDirectory><!-- usually target, if not redefined in pom.xml -->
+            <prettyPrint>true</prettyPrint>
             <verbose>false</verbose><!-- = ${cyclonedx.verbose} -->
         </configuration>
     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>org.cyclonedx</groupId>
             <artifactId>cyclonedx-core-java</artifactId>
-            <version>9.0.5</version>
+            <version>12.2.0</version>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>

--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -95,6 +95,16 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
     private String outputFormat;
 
     /**
+     * Whether the CycloneDX output should be pretty printed (the historical default) or not.  If SBOMs are only
+     * intended for tool/machine consumption disabling pretty printing will reduce the size of the SBOMs by
+     * not including non-functional whitespace that is only of value to human consumers.
+     *
+     * @since 2.9.3
+     */
+    @Parameter(property = "prettyPrint", defaultValue = "true", required = false)
+    private boolean prettyPrint;
+
+    /**
      * The CycloneDX output file name (without extension) that should be generated (in {@code outputDirectory} directory).
      *
      * @since 2.2.0
@@ -441,15 +451,15 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
             MojoExecutionException {
         if ("all".equalsIgnoreCase(outputFormat) || "xml".equalsIgnoreCase(outputFormat)) {
             final BomXmlGenerator bomGenerator = BomGeneratorFactory.createXml(schemaVersion(), bom);
-            //bomGenerator.generate();
 
-            final String bomString = bomGenerator.toXmlString();
+            // TODO Overload that exposes prettyPrint flag not exposed in public API currently
+            final String bomString = bomGenerator.toXmlString(/*prettyPrint*/);
             saveBomToFile(bomString, "xml", new XmlParser());
         }
         if ("all".equalsIgnoreCase(outputFormat) || "json".equalsIgnoreCase(outputFormat)) {
             final BomJsonGenerator bomGenerator = BomGeneratorFactory.createJson(schemaVersion(), bom);
 
-            final String bomString = bomGenerator.toJsonString();
+            final String bomString = bomGenerator.toJsonString(prettyPrint);
             saveBomToFile(bomString, "json", new JsonParser());
         }
     }

--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -96,6 +96,16 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
     private String outputFormat;
 
     /**
+     * Whether the CycloneDX output should be pretty printed (the historical default) or not.  If SBOMs are only
+     * intended for tool/machine consumption disabling pretty printing will reduce the size of the SBOMs by
+     * not including non-functional whitespace that is only of value to human consumers.
+     *
+     * @since 2.9.3
+     */
+    @Parameter(property = "prettyPrint", defaultValue = "true", required = false)
+    private boolean prettyPrint;
+
+    /**
      * The CycloneDX output file name (without extension) that should be generated (in {@code outputDirectory} directory).
      *
      * @since 2.2.0
@@ -447,15 +457,14 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
             MojoExecutionException {
         if ("all".equalsIgnoreCase(outputFormat) || "xml".equalsIgnoreCase(outputFormat)) {
             final BomXmlGenerator bomGenerator = BomGeneratorFactory.createXml(schemaVersion(), bom);
-            //bomGenerator.generate();
 
-            final String bomString = bomGenerator.toXmlString();
+            final String bomString = bomGenerator.toXmlString(prettyPrint);
             saveBomToFile(bomString, "xml", new XmlParser());
         }
         if ("all".equalsIgnoreCase(outputFormat) || "json".equalsIgnoreCase(outputFormat)) {
             final BomJsonGenerator bomGenerator = BomGeneratorFactory.createJson(schemaVersion(), bom);
 
-            final String bomString = bomGenerator.toJsonString();
+            final String bomString = bomGenerator.toJsonString(prettyPrint);
             saveBomToFile(bomString, "json", new JsonParser());
         }
     }


### PR DESCRIPTION
# Context

CycloneDX SBOMs contain a lot of information (by design) which for small modules with large dependency trees can actually lead to the SBOM being the largest artefact in a module by some margin.  With Maven Central planning to bring in [publishing limits](https://central.sonatype.org/publish/maven-central-publishing-limits/#maven-central-publishing-limits) we've been deep auditing what our open source releases produce to reduce unnecessary publishing and try to keep within the proposed size limit (80MB/month) as much as possible.

Once we eliminate the more obvious things that we shouldn't be publishing to Maven Central (e.g. fat JARs for local dev testing/tools, `tests` JARs for modules with no reusable test harnesses etc.) the SBOMs remain the largest contributor to release size.  For example on one large multi-module repository the SBOMs are the biggest artefact for over half of our modules and represent approximately 1/3 of total released bytes.

If we were able to generate non-pretty printed versions of the SBOMs (since ultimately SBOMs are for machine/tool consumption anyway) then some basic testing with tools like `jq` shows we could save up to 150 kilobytes per SBOM.  For a large multi-module project that adds up to megabytes of savings, which when we're talking about an 80MB/month publishing limit is not insignificant. 

This plugin relies on the `cyclonedx-core-java` library which exposes the pretty printing flag for JSON, though not currently for XML, a related PR CycloneDX/cyclonedx-core-java#873 has been opened to add that functionality to the XML generator.  This plugin is currently left as draft for discussion until the upstream PR has been merged and released.

# Code Changes

The SBOMs produced by the plugin are currently always pretty printed which can add a lot of whitespace when generating SBOMs for projects with large dependency trees.  This commit updates the plugin to allow for pretty printing behaviour to be configurable.  For backwards compatibility the default remains to pretty print.

Note that the pretty printing flag was not exposed in the 9.x version of the library that the plugin currently uses so this PR also upgrades the library to the latest 12.x version.