### PR TITLE
add CycloneDX 1.7 support, test all schema versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Default Values
         <artifactId>cyclonedx-maven-plugin</artifactId>
         <configuration>
             <projectType>library</projectType>
-            <schemaVersion>1.6</schemaVersion>
+            <schemaVersion>1.7</schemaVersion>
             <includeBomSerialNumber>true</includeBomSerialNumber>
             <includeCompileScope>true</includeCompileScope>
             <includeProvidedScope>true</includeProvidedScope>
@@ -99,6 +99,7 @@ the CycloneDX version supported by the target system.
 
 | Version | Schema Version | Format(s) |
 |---------|----------------| --------- |
+| 2.10.x  | CycloneDX v1.7 | XML/JSON |
 | 2.9.x   | CycloneDX v1.6 | XML/JSON |
 | 2.8.x   | CycloneDX v1.5 | XML/JSON |
 | 2.6.x   | CycloneDX v1.4 | XML/JSON |

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>org.cyclonedx</groupId>
             <artifactId>cyclonedx-core-java</artifactId>
-            <version>13.0.0</version>
+            <version>13.1.0</version>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>org.cyclonedx</groupId>
             <artifactId>cyclonedx-core-java</artifactId>
-            <version>9.0.5</version>
+            <version>13.0.0</version>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>

--- a/src/it/makeBom/verify.groovy
+++ b/src/it/makeBom/verify.groovy
@@ -10,7 +10,7 @@ assert bomFileXml.text.contains('<reference type="website">\n' +
 
 assert !bomFileXml.text.contains('<property name="maven.optional.unused">')
 
-assert bomFileJson.text.contains('"specVersion" : "1.6"')
+assert bomFileJson.text.contains('"specVersion" : "1.7"')
 
 // Reproducible Builds
 assert !bomFileJson.text.contains('"timestamp"')
@@ -28,3 +28,6 @@ assert bomAggregateFileXml.exists()
 assert bomAggregateFileJson.exists()
 
 assert ! new File(basedir, "build.log").text.contains('[INFO] CycloneDX: Parameters')
+
+// regression for https://github.com/CycloneDX/cyclonedx-maven-plugin/issues/564
+assert ! new File(basedir, "build.log").text.contains('Unknown keyword')

--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -82,7 +82,7 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
      *
      * @since 2.1.0
      */
-    @Parameter(property = "schemaVersion", defaultValue = "1.6", required = false)
+    @Parameter(property = "schemaVersion", defaultValue = "1.7", required = false)
     private String schemaVersion;
     private Version effectiveSchemaVersion = null;
 
@@ -493,8 +493,10 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
                 effectiveSchemaVersion = Version.VERSION_14;
             } else if ("1.5".equals(schemaVersion)) {
                 effectiveSchemaVersion = Version.VERSION_15;
-            } else {
+            } else if ("1.6".equals(schemaVersion)) {
                 effectiveSchemaVersion = Version.VERSION_16;
+            } else {
+                effectiveSchemaVersion = Version.VERSION_17;
             }
         }
         return effectiveSchemaVersion;

--- a/src/main/java/org/cyclonedx/maven/DefaultModelConverter.java
+++ b/src/main/java/org/cyclonedx/maven/DefaultModelConverter.java
@@ -329,7 +329,7 @@ public class DefaultModelConverter implements ModelConverter {
             if (artifactLicense.getName() != null && !resolved) {
                 final License license = new License();
                 license.setName(artifactLicense.getName().trim());
-                if (StringUtils.isNotBlank(artifactLicense.getUrl())) {
+                if (StringUtils.isNotBlank(artifactLicense.getUrl()) && Version.VERSION_10 != schemaVersion) {
                     try {
                         final URI uri = new URI(artifactLicense.getUrl().trim());
                         license.setUrl(uri.toString());
@@ -346,7 +346,12 @@ public class DefaultModelConverter implements ModelConverter {
     private boolean resolveLicenseInfo(final LicenseChoice licenseChoice, final LicenseChoice licenseChoiceToResolve, final Version schemaVersion) {
         if (licenseChoiceToResolve != null) {
             if (licenseChoiceToResolve.getLicenses() != null && !licenseChoiceToResolve.getLicenses().isEmpty()) {
-                licenseChoice.addLicense(licenseChoiceToResolve.getLicenses().get(0));
+                final License license = licenseChoiceToResolve.getLicenses().get(0);
+                if (Version.VERSION_10 == schemaVersion) {
+                    // CycloneDX 1.0 does not support the license url element
+                    license.setUrl(null);
+                }
+                licenseChoice.addLicense(license);
                 return true;
             }
             else if (licenseChoiceToResolve.getExpression() != null && Version.VERSION_10 != schemaVersion) {

--- a/src/main/java/org/cyclonedx/maven/DefaultModelConverter.java
+++ b/src/main/java/org/cyclonedx/maven/DefaultModelConverter.java
@@ -40,6 +40,7 @@ import org.cyclonedx.model.License;
 import org.cyclonedx.model.LicenseChoice;
 import org.cyclonedx.model.Metadata;
 import org.cyclonedx.model.Tool;
+import org.cyclonedx.model.VersionFilter;
 import org.cyclonedx.model.metadata.ToolInformation;
 import org.cyclonedx.util.BomUtils;
 import org.cyclonedx.util.LicenseResolver;
@@ -54,8 +55,11 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
 import java.util.TreeMap;
@@ -82,6 +86,48 @@ public class DefaultModelConverter implements ModelConverter {
      */
     @Inject
     private ProjectBuilder mavenProjectBuilder;
+
+    /**
+     * Hash algorithms supported by the current JVM: for example, SHA3 algorithms are not available
+     * on Java 8, and BLAKE/STREEBOG algorithms require a third party security provider.
+     */
+    private static final List<Hash.Algorithm> JVM_SUPPORTED_HASH_ALGORITHMS = jvmSupportedHashAlgorithms();
+
+    private static List<Hash.Algorithm> jvmSupportedHashAlgorithms() {
+        final List<Hash.Algorithm> algorithms = new LinkedList<>();
+        for (Hash.Algorithm algorithm : Hash.Algorithm.values()) {
+            try {
+                MessageDigest.getInstance(algorithm.getSpec());
+                algorithms.add(algorithm);
+            } catch (NoSuchAlgorithmException e) {
+                // algorithm not supported by this JVM, skip it
+            }
+        }
+        return algorithms;
+    }
+
+    private static boolean isAllowedForSchemaVersion(final Hash.Algorithm algorithm, final Version schemaVersion) {
+        try {
+            final VersionFilter filter = Hash.Algorithm.class.getField(algorithm.name()).getAnnotation(VersionFilter.class);
+            return filter == null || schemaVersion.getVersion() >= filter.value().getVersion();
+        } catch (NoSuchFieldException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Calculates the hashes of the given file, using all hash algorithms supported by both
+     * the current JVM and the target schema version.
+     */
+    private static List<Hash> calculateHashes(final File file, final Version schemaVersion) throws IOException {
+        final List<Hash.Algorithm> algorithms = new LinkedList<>();
+        for (Hash.Algorithm algorithm : JVM_SUPPORTED_HASH_ALGORITHMS) {
+            if (isAllowedForSchemaVersion(algorithm, schemaVersion)) {
+                algorithms.add(algorithm);
+            }
+        }
+        return BomUtils.calculateHashes(file, schemaVersion, algorithms);
+    }
 
     public DefaultModelConverter() {
     }
@@ -167,7 +213,7 @@ public class DefaultModelConverter implements ModelConverter {
          
         try {
             logger.debug(BaseCycloneDxMojo.MESSAGE_CALCULATING_HASHES);
-            component.setHashes(BomUtils.calculateHashes(artifact.getFile(), schemaVersion));
+            component.setHashes(calculateHashes(artifact.getFile(), schemaVersion));
         } catch (IOException e) {
             logger.error("Error encountered calculating hashes", e);
         }
@@ -375,7 +421,7 @@ public class DefaultModelConverter implements ModelConverter {
         if (resolved != null) {
             try {
                 resolved.setFile(new File(resolved.getFile() + ".jar"));
-                hashes = BomUtils.calculateHashes(resolved.getFile(), schemaVersion);
+                hashes = calculateHashes(resolved.getFile(), schemaVersion);
             } catch (IOException e) {
                 logger.warn("Unable to calculate hashes of self", e);
             }

--- a/src/test/java/org/cyclonedx/maven/SchemaVersionsTest.java
+++ b/src/test/java/org/cyclonedx/maven/SchemaVersionsTest.java
@@ -1,0 +1,73 @@
+package org.cyclonedx.maven;
+
+import java.io.File;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
+import io.takari.maven.testing.executor.MavenVersions;
+import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies that a valid BOM can be generated for every supported CycloneDX schema version,
+ * in every output format supported by that schema version, and that BOM validation does not
+ * emit "Unknown keyword" warnings
+ * (regression for <a href="https://github.com/CycloneDX/cyclonedx-maven-plugin/issues/564">issue #564</a>).
+ */
+@RunWith(MavenJUnitTestRunner.class)
+@MavenVersions({"3.6.3"})
+public class SchemaVersionsTest extends BaseMavenVerifier {
+
+    private static final String[] XML_ONLY_VERSIONS = {"1.0", "1.1"};
+    private static final String[] XML_AND_JSON_VERSIONS = {"1.2", "1.3", "1.4", "1.5", "1.6", "1.7"};
+
+    public SchemaVersionsTest(MavenRuntimeBuilder runtimeBuilder) throws Exception {
+        super(runtimeBuilder);
+    }
+
+    @Test
+    public void testXmlOnlySchemaVersions() throws Exception {
+        for (String version : XML_ONLY_VERSIONS) {
+            // JSON was introduced with CycloneDX 1.2: only XML is supported for older schema versions
+            generateBom(version, "xml");
+        }
+    }
+
+    @Test
+    public void testXmlAndJsonSchemaVersions() throws Exception {
+        for (String version : XML_AND_JSON_VERSIONS) {
+            generateBom(version, "all");
+        }
+    }
+
+    private void generateBom(String schemaVersion, String outputFormat) throws Exception {
+        File projDir = resources.getBasedir("schema-versions");
+
+        verifier
+                .forProject(projDir)
+                .withCliOption("-Dcurrent.version=" + getCurrentVersion()) // inject cyclonedx-maven-plugin version
+                .withCliOption("-B")
+                .withCliOption("-DschemaVersion=" + schemaVersion)
+                .withCliOption("-DoutputFormat=" + outputFormat)
+                .execute("verify")
+                .assertErrorFreeLog()
+                .assertNoLogText("[WARNING] Invalid schemaVersion") // requested version is supported as-is
+                .assertNoLogText("Unknown keyword") // regression for issue #564
+                .assertLogText("CycloneDX: Creating BOM version " + schemaVersion);
+
+        final File xmlBom = new File(projDir, "target/bom.xml");
+        assertTrue("XML BOM for schema version " + schemaVersion + " not generated", xmlBom.exists());
+        assertTrue("XML BOM does not declare schema version " + schemaVersion,
+                fileRead(xmlBom, true).contains("http://cyclonedx.org/schema/bom/" + schemaVersion));
+
+        if ("all".equals(outputFormat)) {
+            final File jsonBom = new File(projDir, "target/bom.json");
+            assertTrue("JSON BOM for schema version " + schemaVersion + " not generated", jsonBom.exists());
+            assertTrue("JSON BOM does not declare specVersion " + schemaVersion,
+                    fileRead(jsonBom, true).contains("\"specVersion\" : \"" + schemaVersion + "\""));
+        }
+    }
+}

--- a/src/test/resources/schema-versions/pom.xml
+++ b/src/test/resources/schema-versions/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>schema-versions</artifactId>
+    <packaging>jar</packaging>
+    <version>1.0.0</version>
+
+    <name>Test all supported CycloneDX schema versions</name>
+
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.14.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>${current.version}</version>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>makeBom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <!-- schemaVersion and outputFormat are provided via CLI properties by the test -->
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
Fixes #564

## What

### Bump cyclonedx-core-java 9.0.5 -> 13.1.0
This picks up the fix for the `Unknown keyword meta:enum` / `Unknown keyword deprecated` warnings emitted during JSON BOM validation (CycloneDX/cyclonedx-core-java#280, fixed and released in core-java 13.0.0). The `makeBom` IT now asserts that no `Unknown keyword` warning appears in the build log while JSON validation still runs and passes. Bumped from 13.0.0 to 13.1.0 per review suggestion.

### CycloneDX 1.7 support
core-java 13.x supports schema 1.7, so `schemaVersion=1.7` is now accepted. Following the existing convention that the default tracks the latest supported schema, the default (and the fallback for invalid values, as asserted by `VerboseTest` via `CycloneDxSchema.VERSION_LATEST`) is now `1.7`. **Note for reviewers:** this is a behavior change - if you prefer to keep `1.6` as the default and only support 1.7 opt-in, I'm happy to adjust.

### Systematic test coverage for all schema versions
Existing tests only exercised schema versions 1.2/1.3/1.4/1.6 incidentally through issue reproducers. The new `SchemaVersionsTest` generates and validates a BOM for every supported version: 1.0 and 1.1 (XML only, JSON was introduced with 1.2) and 1.2-1.7 (XML + JSON), asserting the requested version is accepted as-is, ends up in the output (`xmlns` / `specVersion`), and no `Unknown keyword` warning is logged.

### Bugfix: invalid `license/url` element in 1.0 BOMs
The new test immediately uncovered that `schemaVersion=1.0` produced a BOM that fails the plugin's own XSD validation: a `<url>` element inside `<license>`, which only exists since schema 1.1. This looks pre-existing and independent of the dependency bump. Fixed in `DefaultModelConverter` by not emitting the license url for 1.0, consistent with the existing `VERSION_10` guards.

### Fix `NoSuchAlgorithmException` on Java 8
core-java 9.x silently skipped hash algorithms unavailable on the current JVM, but since the `BomUtils.calculateHashes(file, schemaVersion)` rewrite it fails hard when a `MessageDigest` is missing - SHA3 only ships with the JDK since Java 9, so CI on Java 8 failed with `SHA3-256 MessageDigest not available`. `DefaultModelConverter` now uses the `calculateHashes(file, schemaVersion, algorithms)` overload, passing only algorithms supported by both the current JVM (probed via `MessageDigest` over `Hash.Algorithm.values()`) and the target schema version (derived from core-java's own `@VersionFilter` annotations - no hardcoded algorithm list, future algorithms are picked up automatically). On Java 9+ the BOM output is unchanged; on Java 8 SHA3 hashes are omitted, matching the released plugin versions.

## Verification
- `mvn clean verify` green: 26 unit tests + 2 invoker ITs
- full test suite green on both JDK 8 (Corretto 8.0.472) and JDK 21
- both IT build logs contain `Writing and validating BOM (JSON)` with zero `Unknown keyword` warnings