### PR TITLE
Replace Maven's deprecated @Component annotation by JSR-330 @Inject

### DIFF
--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -47,6 +47,7 @@ import org.cyclonedx.parsers.JsonParser;
 import org.cyclonedx.parsers.Parser;
 import org.cyclonedx.parsers.XmlParser;
 
+import javax.inject.Inject;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.IOException;
@@ -247,13 +248,13 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
     @Parameter
     private ExternalReference[] externalReferences;
 
-    @org.apache.maven.plugins.annotations.Component
+    @Inject
     private MavenProjectHelper mavenProjectHelper;
 
-    @org.apache.maven.plugins.annotations.Component
+    @Inject
     private ModelConverter modelConverter;
 
-    @org.apache.maven.plugins.annotations.Component
+    @Inject
     private ProjectDependenciesConverter projectDependenciesConverter;
 
     /**

--- a/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
@@ -32,6 +32,7 @@ import org.cyclonedx.maven.ProjectDependenciesConverter.BomDependencies;
 import org.cyclonedx.model.Component;
 import org.cyclonedx.model.Dependency;
 
+import javax.inject.Inject;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -69,7 +70,7 @@ public class CycloneDxMojo extends BaseCycloneDxMojo {
     @Parameter(property = "analyzer", defaultValue = "default")
     private String analyzer; // https://github.com/CycloneDX/cyclonedx-maven-plugin/pull/65
 
-    @org.apache.maven.plugins.annotations.Component
+    @Inject
     private PlexusContainer plexusContainer;
 
     /**


### PR DESCRIPTION
Migrate off Maven's deprecated `@org.apache.maven.plugins.annotations.Component` annotation and instead use the JSR-330 `@javax.inject.Inject` annotation.

That should allow Eclipse-Tycho to migrate it's SBOM plugin, which extends this plugin, to JSR-330 `@Inject` too.

For details, please see:
- https://github.com/eclipse-tycho/tycho/pull/6195#issuecomment-5089230625 ff
