### PR TITLE
Add regression test for projectType in pluginManagement

### DIFF
--- a/src/test/java/org/cyclonedx/maven/Issue632Test.java
+++ b/src/test/java/org/cyclonedx/maven/Issue632Test.java
@@ -1,0 +1,75 @@
+package org.cyclonedx.maven;
+
+import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
+import io.takari.maven.testing.executor.MavenVersions;
+import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.cyclonedx.maven.TestUtils.readXML;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for <a href="https://github.com/CycloneDX/cyclonedx-maven-plugin/issues/632">issue #632</a>:
+ * projectType configured in pluginManagement must be applied to components in an aggregate BOM.
+ */
+@RunWith(MavenJUnitTestRunner.class)
+@MavenVersions({"3.6.3"})
+public class Issue632Test extends BaseMavenVerifier {
+
+    public Issue632Test(MavenRuntimeBuilder runtimeBuilder) throws Exception {
+        super(runtimeBuilder);
+    }
+
+    @Test
+    public void testProjectTypeFromPluginManagement() throws Exception {
+        File projDir = cleanAndBuild("issue-632", null);
+
+        assertComponentTypeInXml(new File(projDir, "target/bom.xml"), "issue-632", "application");
+        assertComponentTypeInXml(new File(projDir, "target/bom.xml"), "issue-632-app", "application");
+        assertJsonValue(new File(projDir, "target/bom.json"), "$.metadata.component.type", "application");
+        assertComponentTypeInJson(new File(projDir, "target/bom.json"), "issue-632-app", "application");
+    }
+
+    private static void assertComponentTypeInXml(File bomFile, String componentName, String expectedType)
+            throws Exception {
+        Document bom = readXML(bomFile);
+        NodeList components = bom.getElementsByTagName("component");
+        for (int i = 0; i < components.getLength(); i++) {
+            Element component = (Element) components.item(i);
+            Element name = (Element) component.getElementsByTagName("name").item(0);
+            if (name != null && componentName.equals(name.getTextContent())) {
+                assertEquals(expectedType, component.getAttribute("type"));
+                return;
+            }
+        }
+        throw new AssertionError("Missing component named " + componentName);
+    }
+
+    private static void assertComponentTypeInJson(File bomFile, String componentName, String expectedType)
+            throws IOException {
+        assertTrue("BOM JSON should exist", bomFile.isFile());
+        String bomJson = new String(Files.readAllBytes(bomFile.toPath()), StandardCharsets.UTF_8);
+        assertThatJson(bomJson)
+                .inPath("$.components[?(@.name == '" + componentName + "')].type")
+                .isArray()
+                .containsExactly(expectedType);
+    }
+
+    private static void assertJsonValue(File bomFile, String jsonPath, String expectedValue)
+            throws IOException {
+        assertTrue("BOM JSON should exist", bomFile.isFile());
+        String bomJson = new String(Files.readAllBytes(bomFile.toPath()), StandardCharsets.UTF_8);
+        assertThatJson(bomJson).inPath(jsonPath).isEqualTo(expectedValue);
+    }
+}

--- a/src/test/resources/issue-632/app/pom.xml
+++ b/src/test/resources/issue-632/app/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>issue-632</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>issue-632-app</artifactId>
+</project>

--- a/src/test/resources/issue-632/pom.xml
+++ b/src/test/resources/issue-632/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>issue-632</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0.0</version>
+
+    <modules>
+        <module>app</module>
+    </modules>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.cyclonedx</groupId>
+                    <artifactId>cyclonedx-maven-plugin</artifactId>
+                    <version>${current.version}</version>
+                    <configuration>
+                        <projectType>application</projectType>
+                        <schemaVersion>1.6</schemaVersion>
+                        <includeBomSerialNumber>true</includeBomSerialNumber>
+                        <includeCompileScope>true</includeCompileScope>
+                        <includeProvidedScope>true</includeProvidedScope>
+                        <includeRuntimeScope>true</includeRuntimeScope>
+                        <includeSystemScope>true</includeSystemScope>
+                        <includeTestScope>false</includeTestScope>
+                        <includeLicenseText>false</includeLicenseText>
+                        <outputReactorProjects>true</outputReactorProjects>
+                        <outputFormat>all</outputFormat>
+                        <outputName>bom</outputName>
+                        <outputDirectory>${project.build.directory}</outputDirectory>
+                        <verbose>true</verbose>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-aggregate-bom</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>makeAggregateBom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
## Summary

- Add a Maven verifier regression test for #632.
- Reproduce a minimal multi-module Maven project with `projectType=application` configured in parent `pluginManagement`.
- Bind `makeAggregateBom` with the reported schema, scopes, output, and verbosity settings.
- Verify the generated aggregate BOM reports both the metadata component and module component as `application` in XML and JSON.

## Behavior

The reported behavior is that a project configured as `application` is generated as `library`. The new test captures the expected `application` type for the root and reactor module. Current upstream master passes this exact reproduction, so no production-code change is included.

## Verification

- `mvn --no-transfer-progress -Dtest=Issue632Test test` — passed.
- `mvn --no-transfer-progress -Dtest=Issue521Test,Issue632Test test` — passed.
- `mvn --no-transfer-progress -Dinvoker.test=makeAggregateBom verify site` — passed; 28 verifier/unit tests passed and the aggregate Invoker test passed.
- Unfiltered `mvn --no-transfer-progress verify site` reached all 28 tests and failed only in the existing `makeBom` Invoker verifier because the Windows checkout produced CRLF while its Groovy assertion expects LF.

The local environment used JDK 25; the verifier explicitly runs Maven 3.6.3, matching the repository's existing test convention. The CI workflow uses JDK 8.

Refs #632