### PR TITLE
Update dependencies to latest Java 8 compatible versions, pin Actions by SHA, extract version properties

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
       with:
         distribution: 'adopt'
         java-version: '8'
@@ -20,7 +20,7 @@ jobs:
       run: mvn --no-transfer-progress verify site
     - name: Deploy documentation
       if: ${{ github.ref == 'refs/heads/master' }}
-      uses: JamesIves/github-pages-deploy-action@v4.7.3
+      uses: JamesIves/github-pages-deploy-action@fa24774553152dd7873cd16ebd8d959b010c5445 # v4.9.0
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: gh-pages

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,6 +13,6 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@eada3c96a64734dd381cfbda23511034e328ddb0 # v7.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,38 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.outputTimestamp>2026-07-30T20:56:12Z</project.build.outputTimestamp>
+
         <junit.version>4.13.2</junit.version>
         <junit5.version>5.14.4</junit5.version>
         <plugin-tools.version>3.15.2</plugin-tools.version>
+        <cyclonedx-core-java.version>13.2.0</cyclonedx-core-java.version>
+        <javax-inject.version>1</javax-inject.version>
+        <commons-codec.version>1.22.1</commons-codec.version>
+        <commons-io.version>2.22.0</commons-io.version>
+        <commons-lang3.version>3.20.0</commons-lang3.version>
+        <maven.version>3.8.7</maven.version>
+        <maven-dependency-tree.version>3.3.0</maven-dependency-tree.version>
+        <maven-dependency-analyzer.version>1.17.1</maven-dependency-analyzer.version>
+        <takari-plugin-testing.version>3.1.1</takari-plugin-testing.version>
+        <!-- takari-lifecycle-plugin 2.0.9+ requires Java 11; CI builds on JDK 8 -->
+        <takari-lifecycle-plugin.version>2.0.8</takari-lifecycle-plugin.version>
+        <json-unit.version>2.40.1</json-unit.version>
+        <cyclonedx-maven-plugin.version>2.9.3</cyclonedx-maven-plugin.version>
+        <sisu-maven-plugin.version>1.1.0</sisu-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
+        <maven-antrun-plugin.version>3.2.0</maven-antrun-plugin.version>
+        <maven-artifact-plugin.version>3.6.1</maven-artifact-plugin.version>
+        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+        <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
+        <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
+        <maven-invoker-plugin.version>3.10.1</maven-invoker-plugin.version>
+        <maven-jar-plugin.version>3.5.1</maven-jar-plugin.version>
+        <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
+        <maven-project-info-reports-plugin.version>3.9.0</maven-project-info-reports-plugin.version>
+        <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
+        <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
+        <maven-site-plugin.version>3.22.0</maven-site-plugin.version>
+        <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     </properties>
 
     <scm>
@@ -94,12 +123,12 @@
         <dependency>
             <groupId>org.cyclonedx</groupId>
             <artifactId>cyclonedx-core-java</artifactId>
-            <version>13.2.0</version>
+            <version>${cyclonedx-core-java.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
-            <version>1</version>
+            <version>${javax-inject.version}</version>
             <scope>provided</scope>
         </dependency>
         <!-- This is already a dependency of CycloneDX Java Core, but due to some Maven configurations,
@@ -107,40 +136,40 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.22.1</version>
+            <version>${commons-codec.version}</version>
         </dependency>
         <!-- Used directly (FileUtils); no longer provided transitively by cyclonedx-core-java 13.2.0+ -->
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.22.0</version>
+            <version>${commons-io.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.20.0</version>
+            <version>${commons-lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>3.8.7</version>
+            <version>${maven.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.8.7</version>
+            <version>${maven.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-dependency-tree</artifactId>
-            <version>3.3.0</version>
+            <version>${maven-dependency-tree.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-dependency-analyzer</artifactId>
-            <version>1.17.1</version>
+            <version>${maven-dependency-analyzer.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.maven</groupId>
@@ -168,14 +197,14 @@
             <artifactId>takari-plugin-integration-testing</artifactId>
             <type>pom</type>
             <scope>test</scope>
-            <version>3.1.1</version>
+            <version>${takari-plugin-testing.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.takari.maven.plugins</groupId>
             <artifactId>takari-plugin-testing</artifactId>
             <scope>test</scope>
-            <version>3.1.1</version>
+            <version>${takari-plugin-testing.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -201,7 +230,7 @@
         <dependency>
             <groupId>net.javacrumbs.json-unit</groupId>
             <artifactId>json-unit-assertj</artifactId>
-            <version>2.40.1</version>
+            <version>${json-unit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -227,7 +256,7 @@
             <plugin><!-- https://github.com/takari/takari-plugin-testing-project/blob/master/testproperties.md -->
                 <groupId>io.takari.maven.plugins</groupId>
                 <artifactId>takari-lifecycle-plugin</artifactId>
-                <version>2.0.8</version><!-- 2.0.9+ requires Java 11; CI builds on JDK 8 -->
+                <version>${takari-lifecycle-plugin.version}</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>
@@ -247,7 +276,7 @@
             <plugin>
                 <groupId>org.eclipse.sisu</groupId>
                 <artifactId>sisu-maven-plugin</artifactId>
-                <version>1.1.0</version>
+                <version>${sisu-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -259,7 +288,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-invoker-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>${maven-invoker-plugin.version}</version>
                 <configuration>
                     <preBuildHookScript>setup</preBuildHookScript>
                     <postBuildHookScript>verify</postBuildHookScript>
@@ -284,7 +313,7 @@
             <plugin>
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
-                <version>2.9.3</version>
+                <version>${cyclonedx-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>cyclonedx-makeBom</id>
@@ -300,7 +329,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>${maven-antrun-plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>pre-site</phase>
@@ -321,17 +350,17 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.5.1</version>
+                    <version>${maven-jar-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.15.0</version>
+                    <version>${maven-compiler-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>${maven-release-plugin.version}</version>
                     <configuration>
                         <releaseProfiles>release</releaseProfiles>
                     </configuration>
@@ -339,22 +368,22 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.12.0</version>
+                    <version>${maven-javadoc-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.22.0</version>
+                    <version>${maven-site-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>3.9.0</version>
+                    <version>${maven-project-info-reports-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>${maven-resources-plugin.version}</version>
                     <configuration>
                         <!-- https://maven.apache.org/plugins/maven-resources-plugin/examples/filtering-properties-files.html -->
                         <propertiesEncoding>UTF-8</propertiesEncoding>
@@ -388,7 +417,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-enforcer-plugin</artifactId>
-                        <version>3.6.3</version>
+                        <version>${maven-enforcer-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>enforce-java</id>
@@ -408,7 +437,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.8</version>
+                        <version>${maven-gpg-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -422,7 +451,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.4.0</version>
+                        <version>${maven-source-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -447,7 +476,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.11.0</version>
+                        <version>${central-publishing-maven-plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>
@@ -468,7 +497,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-artifact-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>${maven-artifact-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.outputTimestamp>2026-07-30T20:56:12Z</project.build.outputTimestamp>
         <junit.version>4.13.2</junit.version>
-        <junit5.version>5.11.2</junit5.version>
+        <junit5.version>5.14.4</junit5.version>
         <plugin-tools.version>3.15.2</plugin-tools.version>
     </properties>
 
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>org.cyclonedx</groupId>
             <artifactId>cyclonedx-core-java</artifactId>
-            <version>13.1.0</version>
+            <version>13.2.0</version>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>
@@ -107,12 +107,18 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.22.0</version>
+            <version>1.22.1</version>
+        </dependency>
+        <!-- Used directly (FileUtils); no longer provided transitively by cyclonedx-core-java 13.2.0+ -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.22.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.19.0</version>
+            <version>3.20.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -221,7 +227,7 @@
             <plugin><!-- https://github.com/takari/takari-plugin-testing-project/blob/master/testproperties.md -->
                 <groupId>io.takari.maven.plugins</groupId>
                 <artifactId>takari-lifecycle-plugin</artifactId>
-                <version>2.0.8</version>
+                <version>2.0.8</version><!-- 2.0.9+ requires Java 11; CI builds on JDK 8 -->
                 <extensions>true</extensions>
                 <executions>
                     <execution>
@@ -241,7 +247,7 @@
             <plugin>
                 <groupId>org.eclipse.sisu</groupId>
                 <artifactId>sisu-maven-plugin</artifactId>
-                <version>1.0.0</version>
+                <version>1.1.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -278,7 +284,7 @@
             <plugin>
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
-                <version>2.8.0</version>
+                <version>2.9.3</version>
                 <executions>
                     <execution>
                         <id>cyclonedx-makeBom</id>
@@ -315,7 +321,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.5.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -462,7 +468,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-artifact-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.6.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/it/makeAggregateBom/api/pom.xml
+++ b/src/it/makeAggregateBom/api/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.cyclonedx</groupId>
             <artifactId>cyclonedx-core-java</artifactId>
-            <version>9.0.5</version>
+            <version>13.2.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/it/makeAggregateBom/central-publishing-maven-plugin/pom.xml
+++ b/src/it/makeAggregateBom/central-publishing-maven-plugin/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.cyclonedx</groupId>
             <artifactId>cyclonedx-core-java</artifactId>
-            <version>9.0.5</version>
+            <version>13.2.0</version>
         </dependency>
     </dependencies>
 

--- a/src/it/makeAggregateBom/skipped/central-publishing-maven-plugin-config/pom.xml
+++ b/src/it/makeAggregateBom/skipped/central-publishing-maven-plugin-config/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.cyclonedx</groupId>
             <artifactId>cyclonedx-core-java</artifactId>
-            <version>9.0.5</version>
+            <version>13.2.0</version>
         </dependency>
     </dependencies>
 

--- a/src/it/makeAggregateBom/skipped/central-publishing-maven-plugin-property/pom.xml
+++ b/src/it/makeAggregateBom/skipped/central-publishing-maven-plugin-property/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.cyclonedx</groupId>
             <artifactId>cyclonedx-core-java</artifactId>
-            <version>9.0.5</version>
+            <version>13.2.0</version>
         </dependency>
     </dependencies>
     

--- a/src/it/makeBom/pom.xml
+++ b/src/it/makeBom/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.cyclonedx</groupId>
             <artifactId>cyclonedx-core-java</artifactId>
-            <version>9.0.5</version>
+            <version>13.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.websphere.appserver.features</groupId>

--- a/src/test/resources/schema-versions/pom.xml
+++ b/src/test/resources/schema-versions/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.14.0</version>
+            <version>3.20.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary

Consolidated dependency, plugin, and GitHub Actions update — supersedes most of the currently open Dependabot PRs and fixes the breakage the newest cyclonedx-core-java introduces. Split into three commits for easier review:

### 1. Dependency updates (latest Java 8 compatible versions)

| Dependency | From | To | Supersedes |
|---|---|---|---|
| org.cyclonedx:cyclonedx-core-java (IT fixture poms) | 9.0.5 | 13.2.0 | #675, #634, #626 (and closes the related Dependabot alerts) |
| org.cyclonedx:cyclonedx-core-java (main pom) | 13.1.0 | 13.2.0 | #627 (obsolete) |
| org.junit:junit-bom | 5.11.2 | 5.14.4 | #686 (see note) |
| org.apache.commons:commons-lang3 (test pom) | 3.14.0 | 3.20.0 | #684 |
| org.apache.commons:commons-lang3 (main pom) | 3.19.0 | 3.20.0 | — |
| commons-codec:commons-codec | 1.22.0 | 1.22.1 | — |
| **commons-io:commons-io (new, explicit)** | — | 2.22.0 | — |
| org.apache.maven.plugins:maven-jar-plugin | 3.5.0 | 3.5.1 | #685 |
| org.apache.maven.plugins:maven-artifact-plugin | 3.6.0 | 3.6.1 | #667 |
| org.eclipse.sisu:sisu-maven-plugin | 1.0.0 | 1.1.0 | #677 |
| org.cyclonedx:cyclonedx-maven-plugin (self BOM) | 2.8.0 | 2.9.3 | — |

**Required fix:** cyclonedx-core-java 13.2.0 no longer pulls in commons-io transitively, but `BaseCycloneDxMojo.saveBomToFile` uses `org.apache.commons.io.FileUtils` directly — without the new explicit dependency every takari harness test fails with `Unresolved compilation problem: FileUtils cannot be resolved`.

**Deliberately held back (Java 8 CI constraint):**
- junit-bom 6.x requires Java 17 — this is why #686 fails CI; 5.14.4 is the latest 5.x
- takari-lifecycle-plugin stays at 2.0.8 — 2.0.9+ ships Java 11 bytecode (`UnsupportedClassVersionError` on the JDK 8 build); noted in a pom comment
- json-unit-assertj stays at 2.40.1 — 3.x+ requires Java 17
- maven-core / maven-plugin-api stay at 3.8.7 — only 4.0.0-rc releases are newer

### 2. GitHub Actions pinned to full commit SHAs

| Action | From | To |
|---|---|---|
| actions/checkout | v6.0.2 | `3d3c42e5aac5ba805825da76410c181273ba90b1` # v7.0.1 (supersedes #670) |
| actions/setup-java | v5 (floating) | `b6effb05e454b25005698d916606bdc6ffcbf961` # v5.7.0 |
| JamesIves/github-pages-deploy-action | v4.7.3 | `fa24774553152dd7873cd16ebd8d959b010c5445` # v4.9.0 (supersedes #681) |
| release-drafter/release-drafter | v6 (floating) | `eada3c96a64734dd381cfbda23511034e328ddb0` # v7.6.0 (supersedes #676) |

Version comments are kept so Dependabot continues updating the pins.

### 3. Versions extracted into Maven properties

All dependency and plugin versions in the pom are now `<artifactId>.version` properties — future bumps become single-line changes. Only the project version and the enforcer's Java requirement remain literal.

## Validation

Run on JDK 8 (temurin/amzn 8u472), mirroring the CI matrix:
- `mvn verify site` — BUILD SUCCESS, 29/29 takari harness tests, all invoker ITs pass
- `mvn -Prelease validate` — release profile resolves all property-referenced plugins

## Supersedes

Closes #626, closes #627, closes #634, closes #667, closes #670, closes #675, closes #676, closes #677, closes #681, closes #684, closes #685.
#686 (junit-bom 6.1.3) cannot be merged while CI builds on JDK 8; this PR applies 5.14.4 instead.
