### PR TITLE
schema versions test keep SBOMs and not hard-code available values

### DIFF
--- a/src/it/makeBom/verify.groovy
+++ b/src/it/makeBom/verify.groovy
@@ -10,6 +10,7 @@ assert bomFileXml.text.contains('<reference type="website">\n' +
 
 assert !bomFileXml.text.contains('<property name="maven.optional.unused">')
 
+// check default schema version
 assert bomFileJson.text.contains('"specVersion" : "1.7"')
 
 // Reproducible Builds

--- a/src/test/java/org/cyclonedx/maven/SchemaVersionsTest.java
+++ b/src/test/java/org/cyclonedx/maven/SchemaVersionsTest.java
@@ -2,6 +2,8 @@ package org.cyclonedx.maven;
 
 import java.io.File;
 
+import org.cyclonedx.Format;
+import org.cyclonedx.Version;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -16,30 +18,21 @@ import static org.junit.Assert.assertTrue;
  * in every output format supported by that schema version, and that BOM validation does not
  * emit "Unknown keyword" warnings
  * (regression for <a href="https://github.com/CycloneDX/cyclonedx-maven-plugin/issues/564">issue #564</a>).
+ * Generated SBOMs are available in target/test-classes/transformed-projects/schema-versions-bom-*.*
  */
 @RunWith(MavenJUnitTestRunner.class)
 @MavenVersions({"3.6.3"})
 public class SchemaVersionsTest extends BaseMavenVerifier {
-
-    private static final String[] XML_ONLY_VERSIONS = {"1.0", "1.1"};
-    private static final String[] XML_AND_JSON_VERSIONS = {"1.2", "1.3", "1.4", "1.5", "1.6", "1.7"};
 
     public SchemaVersionsTest(MavenRuntimeBuilder runtimeBuilder) throws Exception {
         super(runtimeBuilder);
     }
 
     @Test
-    public void testXmlOnlySchemaVersions() throws Exception {
-        for (String version : XML_ONLY_VERSIONS) {
-            // JSON was introduced with CycloneDX 1.2: only XML is supported for older schema versions
-            generateBom(version, "xml");
-        }
-    }
-
-    @Test
-    public void testXmlAndJsonSchemaVersions() throws Exception {
-        for (String version : XML_AND_JSON_VERSIONS) {
-            generateBom(version, "all");
+    public void testSchemaVersions() throws Exception {
+        for (Version version : Version.values()) {
+            String formats = version.getFormats().contains(Format.JSON) ? "all" : "xml";
+            generateBom(version.getVersionString(), formats);
         }
     }
 
@@ -52,19 +45,21 @@ public class SchemaVersionsTest extends BaseMavenVerifier {
                 .withCliOption("-B")
                 .withCliOption("-DschemaVersion=" + schemaVersion)
                 .withCliOption("-DoutputFormat=" + outputFormat)
+                .withCliOption("-DoutputName=schema-versions-bom-" + schemaVersion)
+                .withCliOption("-DoutputDirectory=..")
                 .execute("verify")
                 .assertErrorFreeLog()
                 .assertNoLogText("[WARNING] Invalid schemaVersion") // requested version is supported as-is
                 .assertNoLogText("Unknown keyword") // regression for issue #564
                 .assertLogText("CycloneDX: Creating BOM version " + schemaVersion);
 
-        final File xmlBom = new File(projDir, "target/bom.xml");
+        final File xmlBom = new File(projDir, "../schema-versions-bom-"+ schemaVersion + ".xml");
         assertTrue("XML BOM for schema version " + schemaVersion + " not generated", xmlBom.exists());
         assertTrue("XML BOM does not declare schema version " + schemaVersion,
                 fileRead(xmlBom, true).contains("http://cyclonedx.org/schema/bom/" + schemaVersion));
 
         if ("all".equals(outputFormat)) {
-            final File jsonBom = new File(projDir, "target/bom.json");
+            final File jsonBom = new File(projDir, "../schema-versions-bom-"+ schemaVersion + ".json");
             assertTrue("JSON BOM for schema version " + schemaVersion + " not generated", jsonBom.exists());
             assertTrue("JSON BOM does not declare specVersion " + schemaVersion,
                     fileRead(jsonBom, true).contains("\"specVersion\" : \"" + schemaVersion + "\""));


### PR DESCRIPTION
keeping all generated SBOMs permits easy comparison of what differences are generated from the same project based on the target versions

not hard-coding available versions prepares for future without update