### PR TITLE
Fix failing master workflows and modernize GitHub automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,31 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      # Combine minor and patch updates into a single PR
+      maven-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
       # JsonUnit `2.x` is the last Java 8 compatible major release
       - dependency-name: "net.javacrumbs.json-unit:*"
+        update-types: ["version-update:semver-major"]
+      # JUnit 6.x requires Java 17
+      - dependency-name: "org.junit:junit-bom"
+        update-types: ["version-update:semver-major"]
+      # takari-lifecycle-plugin 2.0.9+ ships Java 11 bytecode
+      - dependency-name: "io.takari.maven.plugins:takari-lifecycle-plugin"
+      # Maven 4.x moves off the 3.x plugin API baseline
+      - dependency-name: "org.apache.maven:*"
         update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      # Combine all action bumps into a single PR
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,9 +1,0 @@
-# Configuration for lock-threads - https://github.com/dessant/lock-threads
-daysUntilLock: 90
-exemptLabels: []
-lockLabel: false
-lockComment: >
-  This thread has been automatically locked since there has not been
-  any recent activity after it was closed. Please open a new issue for
-  related bugs.
-setLockReason: true

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,16 +1,30 @@
-# Configuration for Release Drafter: https://github.com/toolmantim/release-drafter
-name-template: $NEXT_PATCH_VERSION
-tag-template: cyclonedx-maven-plugin-$NEXT_MINOR_VERSION
+# Configuration for Release Drafter: https://github.com/release-drafter/release-drafter
+name-template: $RESOLVED_VERSION
+tag-template: cyclonedx-maven-plugin-$RESOLVED_VERSION
 version-template: $MAJOR.$MINOR.$PATCH
 
-# Emoji reference: https://gitmoji.carloscuesta.me/
+# Bump the version based on the labels of the merged pull requests
+version-resolver:
+  major:
+    labels:
+      - breaking
+  minor:
+    labels:
+      - major-enhancement
+      - major-rfe
+      - enhancement
+      - feature
+      - rfe
+  default: patch
+
 categories:
-  - title: ":boom: Breaking changes"
-    labels: 
+  - title: 💥 Breaking changes
+    labels:
       - breaking
   - title: 🚨 Removed
-    label: removed
-  - title: ":tada: Major features and improvements"
+    labels:
+      - removed
+  - title: 🎉 Major features and improvements
     labels:
       - major-enhancement
       - major-rfe
@@ -18,7 +32,8 @@ categories:
     labels:
       - major-bug
   - title: ⚠️ Deprecated
-    label: deprecated
+    labels:
+      - deprecated
   - title: 🚀 New features and improvements
     labels:
       - enhancement
@@ -30,9 +45,9 @@ categories:
       - fix
       - bugfix
       - regression
-  - title: ":construction_worker: Changes for plugin developers"
+  - title: 👷 Changes for plugin developers
     labels:
-      - developer 
+      - developer
   # Default label used by Dependabot
   - title: 📦 Dependency updates
     labels:
@@ -40,23 +55,41 @@ categories:
       - dependency
       - dependency-upgrade
   - title: 📝 Documentation updates
-    label: documentation
+    labels:
+      - documentation
   - title: 👻 Maintenance
-    labels: 
+    labels:
       - chore
       - internal
       - maintenance
   - title: 🔧 Build
-    label: build           
+    labels:
+      - build
   - title: 🚦 Tests
-    labels: 
+    labels:
       - test
       - tests
+
 exclude-labels:
   - reverted
   - no-changelog
   - skip-changelog
   - invalid
+
+# Label pull requests automatically based on the files they touch
+autolabeler:
+  - label: documentation
+    files:
+      - '**/*.md'
+      - 'src/site/**'
+  - label: tests
+    files:
+      - 'src/test/**'
+      - 'src/it/**'
+  - label: build
+    files:
+      - '.github/**'
+      - 'release.sh'
 
 change-template: '- $TITLE ([#$NUMBER]($URL)) @$AUTHOR'
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -35,7 +35,7 @@ categories:
       - developer 
   # Default label used by Dependabot
   - title: 📦 Dependency updates
-    label: 
+    labels:
       - dependencies
       - dependency
       - dependency-upgrade

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -1,0 +1,33 @@
+name: Lock Threads
+
+on:
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: lock-threads
+
+jobs:
+  lock:
+    permissions:
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2
+        with:
+          issue-inactive-days: 90
+          pr-inactive-days: 90
+          issue-comment: >
+            This thread has been automatically locked since there has not been
+            any recent activity after it was closed. Please open a new issue for
+            related bugs.
+          pr-comment: >
+            This thread has been automatically locked since there has not been
+            any recent activity after it was closed. Please open a new issue for
+            related bugs.
+          issue-lock-reason: resolved
+          pr-lock-reason: resolved

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,30 +1,50 @@
 name: Maven CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   build:
-
-    permissions:
-      # write permission is required to push the documentation to the gh-pages branch
-      contents: write
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
       with:
-        distribution: 'adopt'
+        persist-credentials: false
+    - name: Set up JDK 8
+      uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+      with:
+        distribution: 'temurin'
         java-version: '8'
+        cache: 'maven'
     - name: Build with Maven
       run: mvn --no-transfer-progress verify site
-    - name: Deploy documentation
+    - name: Upload documentation
       if: ${{ github.ref == 'refs/heads/master' }}
-      uses: JamesIves/github-pages-deploy-action@fa24774553152dd7873cd16ebd8d959b010c5445 # v4.9.0
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
       with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BRANCH: gh-pages
-        FOLDER: target/site
+        path: target/site
+
+  deploy-docs:
+    if: ${{ github.ref == 'refs/heads/master' }}
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      # id-token is required for OIDC authentication of the Pages deployment
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - name: Deploy documentation
+      id: deployment
+      uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,9 @@ permissions: {}
 jobs:
   build:
 
+    permissions:
+      # write permission is required to push the documentation to the gh-pages branch
+      contents: write
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,16 +3,25 @@ on:
   push:
     branches:
       - master
+  # pull_request_target runs the autolabeler on PRs from forks (config-only, no PR code is checked out)
+  pull_request_target:
+    types: [opened, reopened, synchronize]
 
 permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   update_release_draft:
     permissions:
       # write permission is required to create a github release
       contents: write
+      # write permission is required for the autolabeler
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@eada3c96a64734dd381cfbda23511034e328ddb0 # v7.6.0
+      - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,40 @@
+name: OSSF Scorecard
+
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: '44 6 * * 2'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  analysis:
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to the code-scanning dashboard
+      security-events: write
+      # Needed to publish results and get a badge
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://github.com/CycloneDX/cyclonedx-maven-plugin/workflows/Maven%20CI/badge.svg)](https://github.com/CycloneDX/cyclonedx-maven-plugin/actions?workflow=Maven+CI)
-[![Maven Central](https://img.shields.io/maven-central/v/org.cyclonedx/cyclonedx-maven-plugin.svg?label=Maven%20Central)](https://maven-badges.herokuapp.com/maven-central/org.cyclonedx/cyclonedx-maven-plugin)
+[![Build Status](https://github.com/CycloneDX/cyclonedx-maven-plugin/actions/workflows/maven.yml/badge.svg)](https://github.com/CycloneDX/cyclonedx-maven-plugin/actions/workflows/maven.yml)
+[![Maven Central](https://img.shields.io/maven-central/v/org.cyclonedx/cyclonedx-maven-plugin.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/org.cyclonedx/cyclonedx-maven-plugin)
 [![License](https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg)][License]
 [![Website](https://img.shields.io/badge/https://-cyclonedx.org-blue.svg)](https://cyclonedx.org/)
 [![Slack Invite](https://img.shields.io/badge/Slack-Join-blue?logo=slack&labelColor=393939)](https://cyclonedx.org/slack/invite)

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 export JAVA_HOME=`/usr/libexec/java_home -v 1.8`
-export PATH=JAVA_HOME/bin:$PATH
+export PATH=$JAVA_HOME/bin:$PATH
 
 read -p "Really deploy to Maven Central repository (Y/N)? "
 if ( [ "$REPLY" == "Y" ] ) then


### PR DESCRIPTION
Fixes the two currently failing workflows on `master` and modernizes the repository automation. All changes were validated end to end on my fork ([patbaumgartner/cyclonedx-maven-plugin](https://github.com/patbaumgartner/cyclonedx-maven-plugin/actions)) where every workflow — Maven CI incl. Pages deployment, Release Drafter, and Scorecard — runs green on exactly these commits.

## Fixes for the failing master builds

- **Release Drafter**: the pinned v7 action strictly validates the config. The "Dependency updates" category used singular `label:` with a *list* of values, which older versions silently tolerated. Renamed to `labels:`.
- **Maven CI deploy step**: the gh-pages push has failed with HTTP 403 on every master build since 583ffc8 (June 2025) introduced `permissions: {}` without granting the deploy step `contents: write`. Solved by switching to the official Pages deployment (see below), which needs no `contents: write` at all.

## ⚠️ Required repository configuration change (admin, at merge time)

This PR replaces the third-party `JamesIves/github-pages-deploy-action` (which force-pushes a `gh-pages` branch) with GitHub's official `actions/upload-pages-artifact` + `actions/deploy-pages`, which deploy via OIDC directly from the workflow.

**A repository admin must switch the Pages source before/when this is merged**, otherwise the deploy job fails with "Not Found":

- **UI**: *Settings → Pages → Build and deployment → Source* → change from "Deploy from a branch" to **"GitHub Actions"**
- **or API**:
  ```
  gh api -X PUT repos/CycloneDX/cyclonedx-maven-plugin/pages -f build_type=workflow
  ```

The currently published site keeps being served until the first workflow deployment replaces it, so there is no downtime. After the first successful deploy, the `gh-pages` branch is obsolete and can be deleted.

Benefits: no `contents: write` token anywhere in CI (the Maven build, which executes arbitrary plugin code, now runs with a read-only token), no third-party deploy action, and no ever-growing `gh-pages` branch history.

## Other changes

**Maven CI**
- `distribution: adopt` → `temurin` (AdoptOpenJDK is deprecated in setup-java)
- Maven dependency caching (`cache: maven`)
- No more duplicate push+PR runs; superseded PR runs are cancelled via `concurrency`
- Deploy split into its own `deploy-docs` job gated on `master`

**Release Drafter**
- `version-resolver` + `$RESOLVED_VERSION`: the draft name and tag now agree and are driven by PR labels (previously the name bumped *patch* while the tag template bumped *minor*)
- Autolabeler for documentation/test/build changes (runs on `pull_request_target`, config-only, no PR code checked out)
- Normalized all categories to `labels:` lists and fixed the stale `toolmantim` link

> Note: the autolabeler references `documentation` and `tests` labels which don't exist in this repository yet — please create them (the release-notes categories already referenced them).

**Dependabot**
- `groups`: minor/patch Maven bumps and all GitHub Actions bumps arrive as combined PRs instead of dozens of individual ones
- Encoded the known Java 8 ceilings as ignores (JUnit 6 requires Java 17, takari-lifecycle 2.0.9+ ships Java 11 bytecode, Maven 4.x leaves the 3.x plugin API baseline)

**New security workflow**
- **OSSF Scorecard**: weekly + on master pushes, publishing to the code-scanning dashboard and the OSSF API
- A workflow-based CodeQL config was deliberately *not* added: this repository has CodeQL **default setup** enabled, which rejects SARIF uploads from advanced (workflow) configurations — an earlier revision of this PR included one and its checks failed for exactly that reason

**Housekeeping**
- Replaced `.github/lock.yml` — config for the long-retired Probot lock app, dead for years — with a scheduled `dessant/lock-threads` workflow preserving the same 90-day policy and comment
- `release.sh` exported `PATH=JAVA_HOME/bin` (missing `$`), so the JDK 8 selection never took effect
- README: Maven Central badge linked to `maven-badges.herokuapp.com` (dead since Heroku retired the free tier) → `central.sonatype.com`; CI badge updated to the current workflow badge URL format

All actions are pinned to full commit SHAs with `# vX.Y.Z` comments so Dependabot keeps updating them, and every job runs with a least-privilege token. The pending Dependabot bumps #690 (setup-java v6.0.0) and #691 (release-drafter v7.7.0) are already incorporated here, so this PR supersedes both.


