### PR TITLE
add CDX 1.7 isExternal and versionRange support

### DIFF
--- a/src/it/shipped-or-not-deps/shipped/springboot-jetty/pom.xml
+++ b/src/it/shipped-or-not-deps/shipped/springboot-jetty/pom.xml
@@ -27,10 +27,9 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
     <artifactId>sprinboot-jetty</artifactId>
-    <packaging>war</packaging><!-- https://maven.apache.org/ref/3.9.9/maven-core/default-bindings.html#Plugin_bindings_for_war_packaging invokes maven-war-plugin -->
 
-    <name>shipped dependencies: springboot-jetty war</name>
-    <description>Maven War Plugin copies shipped dependencies to WEB-INF/lib/ as per war spec.</description>
+    <name>shipped dependencies: springboot-jetty executable jar attached</name>
+    <description>TBD</description>
 
     <dependencies>
         <dependency>
@@ -77,6 +76,17 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>2.1.18.RELEASE</version>
+                <configuration>
+                    <!-- do not replace but attach in addition -->
+                    <classifier>exec</classifier>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/it/shipped-or-not-deps/shipped/springboot-jetty/src/main/java/org/cyclonedx/its/springboot/jetty/Application.java
+++ b/src/it/shipped-or-not-deps/shipped/springboot-jetty/src/main/java/org/cyclonedx/its/springboot/jetty/Application.java
@@ -1,0 +1,11 @@
+package org.cyclonedx.its.springboot.jetty;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/src/it/shipped-or-not-deps/shipped/springboot-undertow/pom.xml
+++ b/src/it/shipped-or-not-deps/shipped/springboot-undertow/pom.xml
@@ -27,10 +27,9 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
     <artifactId>sprinboot-undertow</artifactId>
-    <packaging>war</packaging><!-- https://maven.apache.org/ref/3.9.9/maven-core/default-bindings.html#Plugin_bindings_for_war_packaging invokes maven-war-plugin -->
 
-    <name>shipped dependencies: springboot-undertow war</name>
-    <description>Maven War Plugin copies shipped dependencies to WEB-INF/lib/ as per war spec.</description>
+    <name>shipped dependencies: springboot-undertow executable jar</name>
+    <description>TBD.</description>
 
     <dependencies>
         <dependency>
@@ -77,6 +76,13 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>2.1.18.RELEASE</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/it/shipped-or-not-deps/shipped/springboot-undertow/src/main/java/org/cyclonedx/its/springboot/undertow/Application.java
+++ b/src/it/shipped-or-not-deps/shipped/springboot-undertow/src/main/java/org/cyclonedx/its/springboot/undertow/Application.java
@@ -1,0 +1,11 @@
+package org.cyclonedx.its.springboot.undertow;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/src/it/shipped-or-not-deps/verify.groovy
+++ b/src/it/shipped-or-not-deps/verify.groovy
@@ -1,0 +1,12 @@
+import groovy.json.JsonSlurper
+
+File aggregateBom = new File(basedir, "target/bom.json")
+assert aggregateBom.exists() : "aggregate BOM was not generated"
+
+def bom = new JsonSlurper().parse(aggregateBom)
+def war = bom.components.find { component ->
+    component.purl == "pkg:maven/org.cyclonedx.its/war@1.0-SNAPSHOT?type=war"
+}
+
+assert war != null : "war reactor component is missing from aggregate BOM"
+assert war.type == "application" : "war reactor component was not transformed with its own lifecycle plan"

--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -20,9 +20,12 @@ package org.cyclonedx.maven;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.lifecycle.LifecycleExecutor;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginExecution;
 import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
@@ -52,21 +55,17 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 public abstract class BaseCycloneDxMojo extends AbstractMojo {
     static final String CYCLONEDX_PLUGIN_KEY = "org.cyclonedx:cyclonedx-maven-plugin";
     static final String PROJECT_TYPE = "projectType";
 
-    @Parameter(property = "project", readonly = true, required = true)
+    @Inject
     private MavenProject project;
+
+    @Inject
+    private MavenSession session;
 
     /**
      * The component type associated to the SBOM metadata. See
@@ -257,6 +256,12 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
     @Inject
     private ProjectDependenciesConverter projectDependenciesConverter;
 
+    @Inject
+    Map<String, BomTransformer> transformers;
+
+    @Inject
+    private LifecycleExecutor lifecycleExecutor;
+
     /**
      * Various messages sent to console.
      */
@@ -293,15 +298,16 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
     }
 
     /**
-     * Analyze the current Maven project to extract the BOM components list and their dependencies.
+     * Analyze the current Maven project to extract its BOM components list and their dependencies and add to the
+     * global maps.
      *
-     * @param topLevelComponents the PURLs for all top level components
+     * @param reactorComponents the PURLs for all reactor components
      * @param components the components map to fill
      * @param dependencies the dependencies map to fill
      * @return the name of the goal done to extract the BOM to save, or {@code null} to not save result.
      * @throws MojoExecutionException something weird happened...
      */
-    protected abstract String extractComponentsAndDependencies(Set<String> topLevelComponents, Map<String, Component> components, Map<String, Dependency> dependencies) throws MojoExecutionException;
+    protected abstract String extractComponentsAndDependencies(Set<String> reactorComponents, Map<String, Component> components, Map<String, Dependency> dependencies) throws MojoExecutionException;
 
     /**
      * @return {@literal true} if the execution should be skipped.
@@ -330,12 +336,12 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
         }
         logParameters();
 
-        // top level components do not currently set their scope, we track these to prevent merging of scopes
-        final Set<String> topLevelComponents = new LinkedHashSet<>();
+        // reactor components do not currently set their scope as they are not dependencies, we track these to prevent merging of scopes
+        final Set<String> reactorComponents = new LinkedHashSet<>();
         final Map<String, Component> componentMap = new LinkedHashMap<>();
         final Map<String, Dependency> dependencyMap = new LinkedHashMap<>();
 
-        String goal = extractComponentsAndDependencies(topLevelComponents, componentMap, dependencyMap);
+        String goal = extractComponentsAndDependencies(reactorComponents, componentMap, dependencyMap);
         if (goal == null) {
             // just ignore result, no need to save.
             return;
@@ -414,6 +420,17 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
                 Lifecycles lifecycles = new Lifecycles();
                 lifecycles.setLifecycleChoice(Collections.singletonList(build));
                 metadata.setLifecycles(lifecycles);
+            }
+
+            if (schemaVersion().getVersion() >= 1.7) {
+                // cleanup version vs versionRange based on isExternal
+                components.forEach(c -> {
+                    if (c.getIsExternal() != null && c.getIsExternal()) {
+                        c.setVersion(null);
+                    } else {
+                        c.setVersionRange(null);
+                    }
+                });
             }
 
             if ("all".equalsIgnoreCase(outputFormat)
@@ -518,20 +535,24 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
         }
     }
 
-    protected void populateComponents(final Set<String> topLevelComponents, final Map<String, Component> components, final Map<String, Artifact> artifacts, final ProjectDependencyAnalysis dependencyAnalysis) {
+    protected Map<String, Component> populateComponents(final Set<String> topLevelComponents, final Map<String, Component> aggregatedComponents, final Map<String, Artifact> artifacts, final ProjectDependencyAnalysis dependencyAnalysis) {
+        final Map<String, Component> components = new HashMap<>();
         for (Map.Entry<String, Artifact> entry: artifacts.entrySet()) {
             final String purl = entry.getKey();
             final Artifact artifact = entry.getValue();
             final Component.Scope artifactScope = getComponentScope(artifact, dependencyAnalysis);
-            final Component component = components.get(purl);
+            final Component component = aggregatedComponents.get(purl);
             if (component == null) {
                 final Component newComponent = convertMavenDependency(artifact);
                 newComponent.setScope(artifactScope);
+                aggregatedComponents.put(purl, newComponent);
                 components.put(purl, newComponent);
             } else if (!topLevelComponents.contains(purl)) {
                 component.setScope(mergeScopes(component.getScope(), artifactScope));
+                components.put(purl, component);
             }
         }
+        return components;
     }
 
     /**
@@ -636,5 +657,26 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
             }
         }
         return false;
+    }
+
+    /**
+     * Transform Bom content based on plugins goals executions bound to Maven build lifecycle of the current project.
+     */
+    protected void transformBom(final Component metadataComponent, final Map<String, Component> components) throws MojoExecutionException {
+        for(MojoExecution execution: calculateExecutionPlan()) {
+            BomTransformer transformer = transformers.get(execution.getPlugin().getKey() + ':' + execution.getGoal());
+            if (transformer != null) {
+                transformer.transform(execution, metadataComponent, components);
+            }
+        }
+    }
+
+    private List<MojoExecution> calculateExecutionPlan() throws MojoExecutionException {
+        try {
+            return lifecycleExecutor.calculateExecutionPlan(session, "verify").getMojoExecutions();
+        } catch (Exception e) {
+            throw new MojoExecutionException(
+                    String.format("Cannot calculate Maven execution plan, caused by: %s", e.getMessage()), e);
+        }
     }
 }

--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -660,10 +660,10 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
     }
 
     /**
-     * Transform Bom content based on plugins goals executions bound to Maven build lifecycle of the current project.
+     * Transform Bom content based on plugins goals executions bound to Maven build lifecycle of the supplied project.
      */
-    protected void transformBom(final Component metadataComponent, final Map<String, Component> components) throws MojoExecutionException {
-        for(MojoExecution execution: calculateExecutionPlan()) {
+    protected void transformBom(final MavenProject mavenProject, final Component metadataComponent, final Map<String, Component> components) throws MojoExecutionException {
+        for(MojoExecution execution: calculateExecutionPlan(mavenProject)) {
             BomTransformer transformer = transformers.get(execution.getPlugin().getKey() + ':' + execution.getGoal());
             if (transformer != null) {
                 transformer.transform(execution, metadataComponent, components);
@@ -671,9 +671,11 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
         }
     }
 
-    private List<MojoExecution> calculateExecutionPlan() throws MojoExecutionException {
+    private List<MojoExecution> calculateExecutionPlan(final MavenProject mavenProject) throws MojoExecutionException {
         try {
-            return lifecycleExecutor.calculateExecutionPlan(session, "verify").getMojoExecutions();
+            final MavenSession projectSession = session.clone();
+            projectSession.setCurrentProject(mavenProject);
+            return lifecycleExecutor.calculateExecutionPlan(projectSession, "verify").getMojoExecutions();
         } catch (Exception e) {
             throw new MojoExecutionException(
                     String.format("Cannot calculate Maven execution plan, caused by: %s", e.getMessage()), e);

--- a/src/main/java/org/cyclonedx/maven/BomTransformer.java
+++ b/src/main/java/org/cyclonedx/maven/BomTransformer.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of CycloneDX Maven Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx.maven;
+
+import org.apache.maven.plugin.MojoExecution;
+import org.cyclonedx.model.Component;
+
+import java.util.Map;
+
+/**
+ * Update Bom Components to match a plugin that has an impact on SBOM.
+ */
+public interface BomTransformer {
+    /**
+     * Based on goal execution configuration, adapt the component that represents the project being build and/or
+     * the components that are extracted from Maven dependencies.
+     *
+     * @param execution goal execution from build lifecycle
+     * @param metadataComponent component of the project that and will be kept as metadata component in the final Bom
+     * @param components components of the Bom
+     */
+    void transform(MojoExecution execution, Component metadataComponent, Map<String, Component> components);
+}

--- a/src/main/java/org/cyclonedx/maven/CycloneDxAggregateMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxAggregateMojo.java
@@ -105,11 +105,11 @@ public class CycloneDxAggregateMojo extends CycloneDxMojo {
     }
 
     @Override
-    protected String extractComponentsAndDependencies(final Set<String> topLevelComponents, final Map<String, Component> components, final Map<String, Dependency> dependencies) throws MojoExecutionException {
+    protected String extractComponentsAndDependencies(final Set<String> reactorComponents, final Map<String, Component> aggregatedComponents, final Map<String, Dependency> dependencies) throws MojoExecutionException {
         if (! getProject().isExecutionRoot()) {
             // non-root project: let parent class create a module-only BOM?
             if (outputReactorProjects) {
-                return super.extractComponentsAndDependencies(topLevelComponents, components, dependencies);
+                return super.extractComponentsAndDependencies(reactorComponents, aggregatedComponents, dependencies);
             }
             getLog().info("Skipping CycloneDX on non-execution root");
             return null;
@@ -129,10 +129,13 @@ public class CycloneDxAggregateMojo extends CycloneDxMojo {
             final Map<String, Dependency> projectDependencies = bomDependencies.getDependencies();
 
             final Component projectBomComponent = convertMavenDependency(mavenProject.getArtifact());
-            components.put(projectBomComponent.getPurl(), projectBomComponent);
-            topLevelComponents.add(projectBomComponent.getPurl());
+            aggregatedComponents.put(projectBomComponent.getPurl(), projectBomComponent);
+            reactorComponents.add(projectBomComponent.getPurl());
 
-            populateComponents(topLevelComponents, components, bomDependencies.getArtifacts(), doProjectDependencyAnalysis(mavenProject, bomDependencies));
+            final Map<String, Component> components = populateComponents(reactorComponents, aggregatedComponents, bomDependencies.getArtifacts(), doProjectDependencyAnalysis(mavenProject, bomDependencies));
+
+            // TODO manage aggregate that reuses a component already used in a different context
+            transformBom(projectBomComponent, components);
 
             projectDependencies.forEach(dependencies::putIfAbsent);
         }

--- a/src/main/java/org/cyclonedx/maven/CycloneDxAggregateMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxAggregateMojo.java
@@ -135,7 +135,7 @@ public class CycloneDxAggregateMojo extends CycloneDxMojo {
             final Map<String, Component> components = populateComponents(reactorComponents, aggregatedComponents, bomDependencies.getArtifacts(), doProjectDependencyAnalysis(mavenProject, bomDependencies));
 
             // TODO manage aggregate that reuses a component already used in a different context
-            transformBom(projectBomComponent, components);
+            transformBom(mavenProject, projectBomComponent, components);
 
             projectDependencies.forEach(dependencies::putIfAbsent);
         }

--- a/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
@@ -18,6 +18,8 @@
  */
 package org.cyclonedx.maven;
 
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.lifecycle.LifecycleExecutor;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -112,17 +114,20 @@ public class CycloneDxMojo extends BaseCycloneDxMojo {
         return "module skips deploy";
     }
 
-    protected String extractComponentsAndDependencies(final Set<String> topLevelComponents, final Map<String, Component> components, final Map<String, Dependency> dependencies) throws MojoExecutionException {
+    protected String extractComponentsAndDependencies(final Set<String> reactorComponents, final Map<String, Component> aggregatedComponents, final Map<String, Dependency> dependencies) throws MojoExecutionException {
         getLog().info(MESSAGE_RESOLVING_DEPS);
 
         final BomDependencies bomDependencies = extractBOMDependencies(getProject());
         final Map<String, Dependency> projectDependencies = bomDependencies.getDependencies();
 
         final Component projectBomComponent = convertMavenDependency(getProject().getArtifact());
-        components.put(projectBomComponent.getPurl(), projectBomComponent);
-        topLevelComponents.add(projectBomComponent.getPurl());
+        aggregatedComponents.put(projectBomComponent.getPurl(), projectBomComponent);
+        reactorComponents.add(projectBomComponent.getPurl());
 
-        populateComponents(topLevelComponents, components, bomDependencies.getArtifacts(), doProjectDependencyAnalysis(getProject(), bomDependencies));
+        final Map<String, Component> components = populateComponents(reactorComponents, aggregatedComponents, bomDependencies.getArtifacts(), doProjectDependencyAnalysis(getProject(), bomDependencies));
+
+        // TODO manage aggregate that reuses a component already used in a different context
+        transformBom(projectBomComponent, components);
 
         projectDependencies.forEach(dependencies::putIfAbsent);
 

--- a/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
@@ -18,8 +18,6 @@
  */
 package org.cyclonedx.maven;
 
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.lifecycle.LifecycleExecutor;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;

--- a/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
@@ -125,7 +125,7 @@ public class CycloneDxMojo extends BaseCycloneDxMojo {
         final Map<String, Component> components = populateComponents(reactorComponents, aggregatedComponents, bomDependencies.getArtifacts(), doProjectDependencyAnalysis(getProject(), bomDependencies));
 
         // TODO manage aggregate that reuses a component already used in a different context
-        transformBom(projectBomComponent, components);
+        transformBom(getProject(), projectBomComponent, components);
 
         projectDependencies.forEach(dependencies::putIfAbsent);
 

--- a/src/main/java/org/cyclonedx/maven/CycloneDxPackageMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxPackageMojo.java
@@ -54,7 +54,7 @@ public class CycloneDxPackageMojo extends BaseCycloneDxMojo {
         return Arrays.asList(new String[]{"war", "ear"}).contains(mavenProject.getPackaging());
     }
 
-    protected String extractComponentsAndDependencies(Set<String> topLevelComponents, Map<String, Component> components, Map<String, Dependency> dependencies) throws MojoExecutionException {
+    protected String extractComponentsAndDependencies(Set<String> reactorComponents, Map<String, Component> aggregatedComponents, Map<String, Dependency> dependencies) throws MojoExecutionException {
         getLog().info(MESSAGE_RESOLVING_DEPS);
 
         for (final MavenProject mavenProject : reactorProjects) {
@@ -67,10 +67,13 @@ public class CycloneDxPackageMojo extends BaseCycloneDxMojo {
             final Map<String, Dependency> projectDependencies = bomDependencies.getDependencies();
 
             final Component projectBomComponent = convertMavenDependency(mavenProject.getArtifact());
-            components.put(projectBomComponent.getPurl(), projectBomComponent);
-            topLevelComponents.add(projectBomComponent.getPurl());
+            aggregatedComponents.put(projectBomComponent.getPurl(), projectBomComponent);
+            reactorComponents.add(projectBomComponent.getPurl());
 
-            populateComponents(topLevelComponents, components, bomDependencies.getArtifacts(), null);
+            final Map<String, Component> components = populateComponents(reactorComponents, aggregatedComponents, bomDependencies.getArtifacts(), null);
+
+            // TODO manage aggregate that reuses a component already used in a different context
+            transformBom(projectBomComponent, components);
 
             projectDependencies.forEach(dependencies::putIfAbsent);
         }

--- a/src/main/java/org/cyclonedx/maven/CycloneDxPackageMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxPackageMojo.java
@@ -73,7 +73,7 @@ public class CycloneDxPackageMojo extends BaseCycloneDxMojo {
             final Map<String, Component> components = populateComponents(reactorComponents, aggregatedComponents, bomDependencies.getArtifacts(), null);
 
             // TODO manage aggregate that reuses a component already used in a different context
-            transformBom(projectBomComponent, components);
+            transformBom(mavenProject, projectBomComponent, components);
 
             projectDependencies.forEach(dependencies::putIfAbsent);
         }

--- a/src/main/java/org/cyclonedx/maven/transformers/AssemblyTransformer.java
+++ b/src/main/java/org/cyclonedx/maven/transformers/AssemblyTransformer.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of CycloneDX Maven Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx.maven.transformers;
+
+import org.apache.maven.plugin.MojoExecution;
+import org.cyclonedx.maven.BomTransformer;
+import org.cyclonedx.model.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.Map;
+
+@Singleton
+@Named("org.apache.maven.plugins:maven-assembly-plugin:single")
+public class AssemblyTransformer implements BomTransformer {
+    private static final Logger LOG = LoggerFactory.getLogger(AssemblyTransformer.class);
+
+    @Override
+    public void transform(MojoExecution execution, Component metadataComponent, Map<String, Component> components) {
+        LOG.info("Work in progress: Assembly transformer not yet implemented");
+    }
+}

--- a/src/main/java/org/cyclonedx/maven/transformers/JarTransformer.java
+++ b/src/main/java/org/cyclonedx/maven/transformers/JarTransformer.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of CycloneDX Maven Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx.maven.transformers;
+
+import org.apache.maven.plugin.MojoExecution;
+import org.cyclonedx.maven.BomTransformer;
+import org.cyclonedx.model.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.Map;
+
+@Singleton
+@Named("org.apache.maven.plugins:maven-jar-plugin:jar")
+public class JarTransformer implements BomTransformer {
+    private static final Logger LOG = LoggerFactory.getLogger(JarTransformer.class);
+
+    @Override
+    public void transform(MojoExecution execution, Component metadataComponent, Map<String, Component> components) {
+        metadataComponent.setType(Component.Type.LIBRARY);
+
+        components.values().forEach(c -> {
+            c.setIsExternal(true);
+            c.setVersionRange("vers:maven/" + c.getVersion() + "|*");
+        });
+    }
+}

--- a/src/main/java/org/cyclonedx/maven/transformers/JarTransformer.java
+++ b/src/main/java/org/cyclonedx/maven/transformers/JarTransformer.java
@@ -39,7 +39,8 @@ public class JarTransformer implements BomTransformer {
 
         components.values().forEach(c -> {
             c.setIsExternal(true);
-            c.setVersionRange("vers:maven/" + c.getVersion() + "|*");
+            // no syntax to clarify that there is a preferred version, even if it can be replaced by any
+            c.setVersionRange("vers:maven/*");
         });
     }
 }

--- a/src/main/java/org/cyclonedx/maven/transformers/JarTransformer.java
+++ b/src/main/java/org/cyclonedx/maven/transformers/JarTransformer.java
@@ -35,7 +35,8 @@ public class JarTransformer implements BomTransformer {
 
     @Override
     public void transform(MojoExecution execution, Component metadataComponent, Map<String, Component> components) {
-        metadataComponent.setType(Component.Type.LIBRARY);
+        // TODO improve aggregate behaviour, as changing component type breaks unit test 521
+        //metadataComponent.setType(Component.Type.LIBRARY);
 
         components.values().forEach(c -> {
             c.setIsExternal(true);

--- a/src/main/java/org/cyclonedx/maven/transformers/ShadeTransformer.java
+++ b/src/main/java/org/cyclonedx/maven/transformers/ShadeTransformer.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of CycloneDX Maven Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx.maven.transformers;
+
+import org.apache.maven.plugin.MojoExecution;
+import org.cyclonedx.maven.BomTransformer;
+import org.cyclonedx.model.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.Map;
+
+@Singleton
+@Named("org.apache.maven.plugins:maven-shade-plugin:shade")
+public class ShadeTransformer implements BomTransformer {
+    private static final Logger LOG = LoggerFactory.getLogger(ShadeTransformer.class);
+
+    @Override
+    public void transform(MojoExecution execution, Component metadataComponent, Map<String, Component> components) {
+        LOG.info("Work in progress: Shade transformer not yet implemented");
+        // TODO manage flexible configurations of the goal https://maven.apache.org/plugins/maven-shade-plugin/shade-mojo.html
+    }
+}

--- a/src/main/java/org/cyclonedx/maven/transformers/SpringBootRepackageTransformer.java
+++ b/src/main/java/org/cyclonedx/maven/transformers/SpringBootRepackageTransformer.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of CycloneDX Maven Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx.maven.transformers;
+
+import org.apache.maven.plugin.MojoExecution;
+import org.cyclonedx.maven.BomTransformer;
+import org.cyclonedx.model.Component;
+import org.cyclonedx.model.Pedigree;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.Map;
+
+@Singleton
+@Named("org.springframework.boot:spring-boot-maven-plugin:repackage")
+public class SpringBootRepackageTransformer implements BomTransformer {
+    private static final Logger LOG = LoggerFactory.getLogger(SpringBootRepackageTransformer.class);
+
+    @Override
+    public void transform(MojoExecution execution, Component metadataComponent, Map<String, Component> components) {
+        metadataComponent.setType(Component.Type.APPLICATION);
+
+        components.values().forEach(c -> {
+            c.setIsExternal(false);
+            Pedigree p = new Pedigree();
+            c.setPedigree(p);
+            p.setNotes("stored in BOOT-INF/lib/");
+        });
+
+        // TODO should it also contain the fact that the boot loader has been shaded?
+
+        // TODO manage advanced configurations https://docs.spring.io/spring-boot/maven-plugin/packaging.html#packaging.repackage-goal
+    }
+}

--- a/src/main/java/org/cyclonedx/maven/transformers/WarTransformer.java
+++ b/src/main/java/org/cyclonedx/maven/transformers/WarTransformer.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of CycloneDX Maven Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx.maven.transformers;
+
+import org.apache.maven.plugin.MojoExecution;
+import org.cyclonedx.maven.BomTransformer;
+import org.cyclonedx.model.Component;
+import org.cyclonedx.model.Pedigree;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.Map;
+
+@Singleton
+@Named("org.apache.maven.plugins:maven-war-plugin:war")
+public class WarTransformer implements BomTransformer {
+    private static final Logger LOG = LoggerFactory.getLogger(WarTransformer.class);
+
+    @Override
+    public void transform(MojoExecution execution, Component metadataComponent, Map<String, Component> components) {
+        metadataComponent.setType(Component.Type.APPLICATION);
+
+        components.values().forEach(c -> {
+            c.setIsExternal(false);
+            Pedigree p = new Pedigree();
+            c.setPedigree(p);
+            p.setNotes("stored in WEB-INF/lib/");
+        });
+
+        // TODO manage advanced configurations of the goal https://maven.apache.org/plugins/maven-war-plugin/war-mojo.html
+        // - attachClasses
+    }
+}

--- a/src/test/java/org/cyclonedx/maven/Issue521Test.java
+++ b/src/test/java/org/cyclonedx/maven/Issue521Test.java
@@ -31,6 +31,12 @@ public class Issue521Test extends BaseMavenVerifier {
     @Test
     public void testBomJsonContent() throws Exception {
         File projDir = cleanAndBuild("issue-521", null);
+
+        // check SBOM for the app module, as configured in app/pom.xml
+        checkBomXml(projDir, "app/target/bom.xml", "issue-521-app", "application");
+        checkBomJson(projDir, "app/target/bom.json", "issue-521-app", "application");
+
+        // check aggregated SBOM for the multi-module project
         checkBomXml(projDir, "target/bom.xml", "issue-521-app", "application");
         checkBomJson(projDir, "target/bom.json", "issue-521-app", "application");
     }
@@ -46,9 +52,9 @@ public class Issue521Test extends BaseMavenVerifier {
         // Leggi il contenuto del file bom.json e verifica la presenza dei campi desiderati
         String bomContents = fileRead(bomJsonFile, true);
         assertTrue(bomContents.contains("\"name\" : \"" + expectedName + "\""), 
-            String.format("bom.json should contain a module with name '%s'", expectedName));
+            String.format(filePath + " should contain a module with name '%s'", expectedName));
         assertTrue(bomContents.contains("\"type\" : \"" + expectedType + "\""), 
-            String.format("bom.json should contain a module with type '%s'", expectedType));
+            String.format(filePath + " should contain a module with type '%s'", expectedType));
     }
 
     private void checkBomXml(File basedir, String filePath, String expectedName, String expectedType) throws Exception {
@@ -72,6 +78,6 @@ public class Issue521Test extends BaseMavenVerifier {
             }
         }
 
-        assertTrue(found, "Expected to find a component with name 'module1' and type 'application'");
+        assertTrue(found, "Expected to find a component with name 'module1' and type 'application' in " + filePath);
     }
 }


### PR DESCRIPTION
`isExternal` https://cyclonedx.org/docs/1.7/json/#metadata_tools_oneOf_i0_components_items_isExternal
`versionRange` https://cyclonedx.org/docs/1.7/json/#metadata_tools_oneOf_i0_components_items_versionRange

By default, `isExternal` is false: all components described are included in what the SBOM describes

bBut for Java libraries, for example, need to mark `isExternal=true` as the dependency is not shipped, but will be resolved by consuming project and eventually its version changed based on Maven conflict resolution.
In this case, `version` is replaced by `versionRange=vers:maven/{{version}}|*`, which shows how default version is still there, but may be replaced by any other when consumed.

This PR adds a `BomTransformer` interface to transform components details based on what plugin goals are executed during the Maven build (= implement #683):
- `jar` is by default for libraries, with components `isExternal=true`
- `war` is the exact contrary: components are changed to `isExternal=false`
- same for Spring Boot: `isExternal=false`
- `shade` require some work to understand details of the plugin configuration, as it is very flexible at defining what is external or not (=shaded) (see https://github.com/CycloneDX/cyclonedx-maven-plugin/issues/472#issuecomment-5451448049 that was used as an inspiration for this PR)

This PR is not yet complete regarding all packaging plugins that can have an impact: missing assembly and Quarkus, for example, but probably many more.

This new framework also introduce some complexities that still need to be handled:
- aggregate SBOM: one library may be external in one context, but NOT external in another, so each component may require multiple `bom-ref` to keep the difference
- one Maven project may produce 2 different .jar: one fatjar with dependencies embedded, and the initial jar with no embeddings. Currently, `makeBom` creates only one SBOM by design: we'll have to change that, it seems...
notice: https://github.com/CycloneDX/cyclonedx-maven-plugin/issues/680#issuecomment-5461453193 may be another change that will be required