### PR TITLE
fix: calculate transformer lifecycle per reactor project

### DIFF
--- a/src/it/shipped-or-not-deps/verify.groovy
+++ b/src/it/shipped-or-not-deps/verify.groovy
@@ -1,0 +1,12 @@
+import groovy.json.JsonSlurper
+
+File aggregateBom = new File(basedir, "target/bom.json")
+assert aggregateBom.exists() : "aggregate BOM was not generated"
+
+def bom = new JsonSlurper().parse(aggregateBom)
+def war = bom.components.find { component ->
+    component.purl == "pkg:maven/org.cyclonedx.its/war@1.0-SNAPSHOT?type=war"
+}
+
+assert war != null : "war reactor component is missing from aggregate BOM"
+assert war.type == "application" : "war reactor component was not transformed with its own lifecycle plan"

--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -660,10 +660,10 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
     }
 
     /**
-     * Transform Bom content based on plugins goals executions bound to Maven build lifecycle of the current project.
+     * Transform Bom content based on plugins goals executions bound to Maven build lifecycle of the supplied project.
      */
-    protected void transformBom(final Component metadataComponent, final Map<String, Component> components) throws MojoExecutionException {
-        for(MojoExecution execution: calculateExecutionPlan()) {
+    protected void transformBom(final MavenProject mavenProject, final Component metadataComponent, final Map<String, Component> components) throws MojoExecutionException {
+        for(MojoExecution execution: calculateExecutionPlan(mavenProject)) {
             BomTransformer transformer = transformers.get(execution.getPlugin().getKey() + ':' + execution.getGoal());
             if (transformer != null) {
                 transformer.transform(execution, metadataComponent, components);
@@ -671,9 +671,11 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
         }
     }
 
-    private List<MojoExecution> calculateExecutionPlan() throws MojoExecutionException {
+    private List<MojoExecution> calculateExecutionPlan(final MavenProject mavenProject) throws MojoExecutionException {
         try {
-            return lifecycleExecutor.calculateExecutionPlan(session, "verify").getMojoExecutions();
+            final MavenSession projectSession = session.clone();
+            projectSession.setCurrentProject(mavenProject);
+            return lifecycleExecutor.calculateExecutionPlan(projectSession, "verify").getMojoExecutions();
         } catch (Exception e) {
             throw new MojoExecutionException(
                     String.format("Cannot calculate Maven execution plan, caused by: %s", e.getMessage()), e);

--- a/src/main/java/org/cyclonedx/maven/CycloneDxAggregateMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxAggregateMojo.java
@@ -135,7 +135,7 @@ public class CycloneDxAggregateMojo extends CycloneDxMojo {
             final Map<String, Component> components = populateComponents(reactorComponents, aggregatedComponents, bomDependencies.getArtifacts(), doProjectDependencyAnalysis(mavenProject, bomDependencies));
 
             // TODO manage aggregate that reuses a component already used in a different context
-            transformBom(projectBomComponent, components);
+            transformBom(mavenProject, projectBomComponent, components);
 
             projectDependencies.forEach(dependencies::putIfAbsent);
         }

--- a/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxMojo.java
@@ -127,7 +127,7 @@ public class CycloneDxMojo extends BaseCycloneDxMojo {
         final Map<String, Component> components = populateComponents(reactorComponents, aggregatedComponents, bomDependencies.getArtifacts(), doProjectDependencyAnalysis(getProject(), bomDependencies));
 
         // TODO manage aggregate that reuses a component already used in a different context
-        transformBom(projectBomComponent, components);
+        transformBom(getProject(), projectBomComponent, components);
 
         projectDependencies.forEach(dependencies::putIfAbsent);
 

--- a/src/main/java/org/cyclonedx/maven/CycloneDxPackageMojo.java
+++ b/src/main/java/org/cyclonedx/maven/CycloneDxPackageMojo.java
@@ -73,7 +73,7 @@ public class CycloneDxPackageMojo extends BaseCycloneDxMojo {
             final Map<String, Component> components = populateComponents(reactorComponents, aggregatedComponents, bomDependencies.getArtifacts(), null);
 
             // TODO manage aggregate that reuses a component already used in a different context
-            transformBom(projectBomComponent, components);
+            transformBom(mavenProject, projectBomComponent, components);
 
             projectDependencies.forEach(dependencies::putIfAbsent);
         }


### PR DESCRIPTION
Stacked on #696.

transformBom() is called while iterating reactor projects, but the lifecycle execution plan is currently calculated from session.getCurrentProject(). In aggregate/package mode that can cause module transforms to use the execution root’s plugin bindings instead of the module being analyzed.

This patch:

* passes the analyzed MavenProject into transformBom();
* clones the MavenSession and sets that project as currentProject before calculating the lifecycle plan;
* adds an Invoker regression proving the WAR grandchild in shipped-or-not-deps is transformed using its own WAR lifecycle.

No changes here to projectType handling, isExternal, versionRange, dependency scope semantics, Assembly support, Quarkus support, aggregate bom-ref redesign, publication behavior, or broader #696 refactoring.
