### PR TITLE
fix: preserve configured project type during transforms

### DIFF
--- a/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
+++ b/src/main/java/org/cyclonedx/maven/BaseCycloneDxMojo.java
@@ -663,12 +663,33 @@ public abstract class BaseCycloneDxMojo extends AbstractMojo {
      * Transform Bom content based on plugins goals executions bound to Maven build lifecycle of the supplied project.
      */
     protected void transformBom(final MavenProject mavenProject, final Component metadataComponent, final Map<String, Component> components) throws MojoExecutionException {
+        final Component.Type configuredProjectType = getConfiguredProjectType(mavenProject, metadataComponent);
+
         for(MojoExecution execution: calculateExecutionPlan(mavenProject)) {
             BomTransformer transformer = transformers.get(execution.getPlugin().getKey() + ':' + execution.getGoal());
             if (transformer != null) {
                 transformer.transform(execution, metadataComponent, components);
             }
         }
+
+        if (configuredProjectType != null) {
+            metadataComponent.setType(configuredProjectType);
+        }
+    }
+
+    /**
+     * Keep an explicitly configured projectType authoritative over lifecycle-based type inference.
+     * The component has already been converted with the effective project configuration, so preserving
+     * its type here avoids making every transformer aware of CycloneDX plugin configuration.
+     */
+    private Component.Type getConfiguredProjectType(final MavenProject mavenProject, final Component metadataComponent) {
+        final Plugin plugin = mavenProject.getPlugin(CYCLONEDX_PLUGIN_KEY);
+        if (plugin == null || !(plugin.getConfiguration() instanceof Xpp3Dom)) {
+            return null;
+        }
+
+        final Xpp3Dom configuration = (Xpp3Dom) plugin.getConfiguration();
+        return configuration.getChild(PROJECT_TYPE) == null ? null : metadataComponent.getType();
     }
 
     private List<MojoExecution> calculateExecutionPlan(final MavenProject mavenProject) throws MojoExecutionException {

--- a/src/main/java/org/cyclonedx/maven/transformers/JarTransformer.java
+++ b/src/main/java/org/cyclonedx/maven/transformers/JarTransformer.java
@@ -35,8 +35,7 @@ public class JarTransformer implements BomTransformer {
 
     @Override
     public void transform(MojoExecution execution, Component metadataComponent, Map<String, Component> components) {
-        // TODO improve aggregate behaviour, as changing component type breaks unit test 521
-        //metadataComponent.setType(Component.Type.LIBRARY);
+        metadataComponent.setType(Component.Type.LIBRARY);
 
         components.values().forEach(c -> {
             c.setIsExternal(true);


### PR DESCRIPTION
Follow-up to #700 and the Issue521 regression discussed there.

Lifecycle transformers should still infer the component type from the build (for example `jar` -> `library`), but an explicitly configured CycloneDX `<projectType>` should win. This keeps the transformer behavior while preserving the module-specific type already resolved by `convertMavenDependency()`.

This patch:
- restores `JarTransformer`'s `library` type inference;
- preserves the pre-transform component type when the effective project config explicitly contains `projectType`;
- leaves lifecycle-based type inference unchanged for projects without an explicit override.

The existing `Issue521Test` on `isExternal` exercises the aggregate case that exposed this: the app module is explicitly `application` even though the jar lifecycle runs.

Commit is DCO-signed and cryptographically signed/Verified.
